### PR TITLE
fix: avoid call audioWorklet.addModule if it's undefined

### DIFF
--- a/packages/voice-chat-codec/VoiceCommunicator.ts
+++ b/packages/voice-chat-codec/VoiceCommunicator.ts
@@ -492,6 +492,7 @@ export class VoiceCommunicator {
       .catch((e) => defaultLogger.error('Error loading worklet modules: ', e))
       return [aContext, workletInitializedPromise]
     }else{
+      // TODO: trackEvent('error_initializing_worklet') to gain visibility about how many times is this issue happening
       defaultLogger.error('Error loading worklet modules: audioWorklet undefined')
       return [aContext, Promise.resolve()]
     }

--- a/packages/voice-chat-codec/VoiceCommunicator.ts
+++ b/packages/voice-chat-codec/VoiceCommunicator.ts
@@ -486,10 +486,15 @@ export class VoiceCommunicator {
 
   private createContext(contextOptions?: AudioContextOptions): AudioContextWithInitPromise {
     const aContext = new AudioContext(contextOptions)
-    const workletInitializedPromise = aContext.audioWorklet
+    if (aContext.audioWorklet){
+      const workletInitializedPromise = aContext.audioWorklet
       .addModule(workletWorkerUrl)
       .catch((e) => defaultLogger.error('Error loading worklet modules: ', e))
-    return [aContext, workletInitializedPromise]
+      return [aContext, workletInitializedPromise]
+    }else{
+      defaultLogger.error('Error loading worklet modules: audioWorklet undefined')
+      return [aContext, Promise.resolve()]
+    }
   }
 
   private destroyOutput(outputId: string) {


### PR DESCRIPTION

<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Add a check for aContext.audioWorklet.

# Why? <!-- Explain the reason -->
For some reason, sometimes AudioContext initializes without audioWorklet defined in it.

![image](https://user-images.githubusercontent.com/8042536/130293568-c937f7ba-42d9-4cf2-a28a-6d06bdb090f7.png)

