### PR TITLE
feat: add network param for unity config

### DIFF
--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -40,6 +40,7 @@ import { onLoginCompleted } from 'shared/session/sagas'
 import { authenticate } from 'shared/session/actions'
 import { localProfilesRepo } from 'shared/profiles/sagas'
 import { getStoredSession } from 'shared/session'
+import { getSelectedNetwork } from 'shared/dao/selectors'
 
 const logger = createLogger('kernel: ')
 
@@ -198,6 +199,7 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
       const configForRenderer = kernelConfigForRenderer()
       configForRenderer.comms.voiceChatEnabled = VOICE_CHAT_ENABLED
       configForRenderer.features.enableBuilderInWorld = BUILDER_IN_WORLD_ENABLED
+      configForRenderer.network = getSelectedNetwork(store.getState())
       i.SetKernelConfiguration(configForRenderer)
 
       configureTaskbarDependentHUD(i, VOICE_CHAT_ENABLED, BUILDER_IN_WORLD_ENABLED)

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -582,6 +582,7 @@ export type KernelConfigForRenderer = {
   }
   gifSupported: boolean
   tld: string
+  network: string
   validWorldRanges: Object
 }
 

--- a/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/packages/unity-interface/kernelConfigForRenderer.ts
@@ -24,6 +24,7 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
       // tslint:disable-next-line
       typeof OffscreenCanvas !== 'undefined' && typeof OffscreenCanvasRenderingContext2D === 'function' && !WSS_ENABLED,
     tld: getTLD(),
+    network: "mainnet",
     validWorldRanges: getWorld().validWorldRanges
   }
 }


### PR DESCRIPTION
# What? 

This PR solves part of @decentraland/unity-team#1008

With these changes, we are sending the network to unity, so we can replace the use of TLD with the new network approach

Until this PR is not merged, we are not able to test things in ropsten that were using TLD in Unity ( builder in world for example)

# Why? 

TLD is deprecated and we need to use the new network in order to know which API we should use.