### PR TITLE
fix: Voice chat sometimes fails in Firefox

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -151,8 +151,8 @@ export const rootURLPreviewMode = () => {
 export const PIN_CATALYST = PREVIEW
   ? rootURLPreviewMode()
   : typeof qs.CATALYST === 'string'
-  ? addHttpsIfNoProtocolIsSet(qs.CATALYST)
-  : undefined
+    ? addHttpsIfNoProtocolIsSet(qs.CATALYST)
+    : undefined
 
 export const FORCE_RENDERING_STYLE = ensureSingleString(qs.FORCE_RENDERING_STYLE) as any
 
@@ -173,10 +173,6 @@ export namespace commConfigurations {
 
   export const iceServers = [
     { urls: 'stun:stun.l.google.com:19302' },
-    { urls: 'stun:global.stun.twilio.com:3478?transport=udp' },
-    {
-      urls: ['stun:stun2.l.google.com:19302', 'stun:stun3.l.google.com:19302', 'stun:stun4.l.google.com:19302']
-    },
     {
       urls: 'turn:stun.decentraland.org:3478',
       credential: 'passworddcl',

--- a/packages/voice-chat-codec/audioWorkletProcessors.ts
+++ b/packages/voice-chat-codec/audioWorkletProcessors.ts
@@ -9,7 +9,7 @@ export interface AudioWorkletProcessor {
 
 declare var AudioWorkletProcessor: {
   prototype: AudioWorkletProcessor
-  new (options?: AudioWorkletNodeOptions): AudioWorkletProcessor
+  new(options?: AudioWorkletNodeOptions): AudioWorkletProcessor
 }
 
 declare function registerProcessor(
@@ -46,25 +46,25 @@ class InputProcessor extends AudioWorkletProcessor {
 
   process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>) {
     if (this.status === InputProcessorStatus.PAUSED) return true
-    let data = inputs[0][0]
+    let inputData = inputs?.[0]?.[0] ?? new Float32Array()
 
     if (this.status === InputProcessorStatus.PAUSE_REQUESTED) {
       // We try to use as many samples as we can that would complete some frames
       const samplesToUse =
-        Math.floor(data.length / OPUS_SAMPLES_PER_FRAME) * OPUS_SAMPLES_PER_FRAME +
+        Math.floor(inputData.length / OPUS_SAMPLES_PER_FRAME) * OPUS_SAMPLES_PER_FRAME +
         OPUS_SAMPLES_PER_FRAME -
         (this.inputSamplesCount % OPUS_SAMPLES_PER_FRAME)
 
       // If we still don't have enough samples to complete a frame, we cannot pause recording yet.
-      if (samplesToUse <= data.length) {
-        data = data.slice(0, samplesToUse)
+      if (samplesToUse <= inputData.length) {
+        inputData = inputData.slice(0, samplesToUse)
         this.status = InputProcessorStatus.PAUSED
         this.notify(InputWorkletRequestTopic.ON_PAUSED)
       }
     }
 
-    this.inputSamplesCount += data.length
-    this.sendDataToEncode(data)
+    this.inputSamplesCount += inputData.length
+    this.sendDataToEncode(inputData)
 
     return true
   }


### PR DESCRIPTION
This PR fixes a corner case that would make Voice Chat completely fail on firefox sometimes.

This doesn't completely fix Voice Chat since there is an issue that I'm still investigating with web workers communication (and that seems to affect more things than just Voice Chat), but should improve the situation.

Also, we should get better connection results with less stun servers.