### PR TITLE
feat: Add kernel and renderer versions to kernelConfigForRenderer data

### DIFF
--- a/packages/shared/rolloutVersions.ts
+++ b/packages/shared/rolloutVersions.ts
@@ -1,0 +1,15 @@
+// this function injects rollout versions to records based on the rollouts
+// {a: asd} -> {a: asd, _site: 1.0.0, @dcl/unity-renderer: 6.0.0}
+export function injectVersions<T extends Record<string, any>>(versions: T): T & Record<string, string> {
+  let rolloutsInfo = (globalThis as any).ROLLOUTS || {}
+
+  for (let component in rolloutsInfo) {
+    if (component === '_site' || component.startsWith('@dcl')) {
+      if (rolloutsInfo[component] && rolloutsInfo[component].version) {
+        versions[component as keyof T] = rolloutsInfo[component].version
+      }
+    }
+  }
+
+  return versions
+}

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -583,8 +583,8 @@ export type KernelConfigForRenderer = {
   gifSupported: boolean
   network: string
   validWorldRanges: Object
-  kernelURL: string
-  rendererURL: string
+  kernelVersion: string
+  rendererVersion: string
 }
 
 export type RealmsInfoForRenderer = {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -583,6 +583,8 @@ export type KernelConfigForRenderer = {
   gifSupported: boolean
   network: string
   validWorldRanges: Object
+  kernelURL: string
+  rendererURL: string
 }
 
 export type RealmsInfoForRenderer = {

--- a/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/packages/unity-interface/kernelConfigForRenderer.ts
@@ -6,6 +6,13 @@ import { isFeatureEnabled } from 'shared/meta/selectors'
 import { FeatureFlags } from 'shared/meta/types'
 import { store } from 'shared/store/isolatedStore'
 
+type Environment = {
+  KERNEL_BASE_URL: string
+  RENDERER_BASE_URL: string
+}
+
+declare const globalThis: Environment
+
 export function kernelConfigForRenderer(): KernelConfigForRenderer {
   return {
     comms: {
@@ -24,6 +31,8 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
       // tslint:disable-next-line
       typeof OffscreenCanvas !== 'undefined' && typeof OffscreenCanvasRenderingContext2D === 'function' && !WSS_ENABLED,
     network: "mainnet",
-    validWorldRanges: getWorld().validWorldRanges
+    validWorldRanges: getWorld().validWorldRanges,
+    kernelURL: globalThis.KERNEL_BASE_URL,
+    rendererURL: globalThis.RENDERER_BASE_URL
   }
 }

--- a/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/packages/unity-interface/kernelConfigForRenderer.ts
@@ -5,13 +5,7 @@ import { getWorld } from '@dcl/schemas'
 import { isFeatureEnabled } from 'shared/meta/selectors'
 import { FeatureFlags } from 'shared/meta/types'
 import { store } from 'shared/store/isolatedStore'
-
-type Environment = {
-  KERNEL_BASE_URL: string
-  RENDERER_BASE_URL: string
-}
-
-declare const globalThis: Environment
+import { injectVersions } from 'shared/rolloutVersions'
 
 export function kernelConfigForRenderer(): KernelConfigForRenderer {
   return {
@@ -32,7 +26,15 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
       typeof OffscreenCanvas !== 'undefined' && typeof OffscreenCanvasRenderingContext2D === 'function' && !WSS_ENABLED,
     network: "mainnet",
     validWorldRanges: getWorld().validWorldRanges,
-    kernelURL: globalThis.KERNEL_BASE_URL,
-    rendererURL: globalThis.RENDERER_BASE_URL
+    kernelVersion: getKernelVersion(),
+    rendererVersion: getRendererVersion()
   }
+}
+
+export function getKernelVersion(): string {
+  return injectVersions({})['@dcl/kernel'] || "unknown-kernel-version"
+}
+
+export function getRendererVersion(): string {
+  return injectVersions({})['@dcl/unity-renderer'] || "unknown-renderer-version"
 }

--- a/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/packages/unity-interface/kernelConfigForRenderer.ts
@@ -8,6 +8,7 @@ import { store } from 'shared/store/isolatedStore'
 import { injectVersions } from 'shared/rolloutVersions'
 
 export function kernelConfigForRenderer(): KernelConfigForRenderer {
+  const versions = injectVersions({})
   return {
     comms: {
       commRadius: commConfigurations.commRadius,

--- a/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/packages/unity-interface/kernelConfigForRenderer.ts
@@ -27,8 +27,8 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
       typeof OffscreenCanvas !== 'undefined' && typeof OffscreenCanvasRenderingContext2D === 'function' && !WSS_ENABLED,
     network: "mainnet",
     validWorldRanges: getWorld().validWorldRanges,
-    kernelVersion: getKernelVersion(),
-    rendererVersion: getRendererVersion()
+    kernelVersion: versions['@dcl/kernel'] || "unknown-kernel-version",
+    rendererVersion: versions['@dcl/unity-renderer'] || "unknown-renderer-version"
   }
 }
 

--- a/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/packages/unity-interface/kernelConfigForRenderer.ts
@@ -31,11 +31,3 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
     rendererVersion: versions['@dcl/unity-renderer'] || "unknown-renderer-version"
   }
 }
-
-export function getKernelVersion(): string {
-  return injectVersions({})['@dcl/kernel'] || "unknown-kernel-version"
-}
-
-export function getRendererVersion(): string {
-  return injectVersions({})['@dcl/unity-renderer'] || "unknown-renderer-version"
-}


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Adds kernel and renderer versions to kernelConfigForRenderer

# Why? <!-- Explain the reason -->
Required for decentraland/unity-renderer#1178 to autocomplete issue form with required data

# How to test
Follow https://github.com/decentraland/unity-renderer/pull/1187 Instructions 