### PR TITLE
fix: wait for renderer's DebugBridge ready before sending debug messages at initialization

### DIFF
--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -69,8 +69,9 @@ import { renderStateObservable } from 'shared/world/worldState'
 import { realmToString } from 'shared/dao/utils/realmToString'
 import { store } from 'shared/store/isolatedStore'
 import { signalRendererInitializedCorrectly } from 'shared/renderer/actions'
+import { ClientDebug } from './ClientDebug'
 
-declare const globalThis: { gifProcessor?: GIFProcessor }
+declare const globalThis: { gifProcessor?: GIFProcessor, clientDebug: ClientDebug }
 export let futures: Record<string, IFuture<any>> = {}
 
 // ** TODO - move to friends related file - moliva - 15/07/2020
@@ -647,6 +648,10 @@ export class BrowserInterface {
     } else {
       defaultLogger.error(`SceneEvent: Scene ${videoEvent.sceneId} not found`, videoEvent)
     }
+  }
+
+  public SetDebugBridgeReady() {
+    globalThis.clientDebug.SetDebugBridgeReady()
   }
 }
 

--- a/packages/unity-interface/ClientDebug.ts
+++ b/packages/unity-interface/ClientDebug.ts
@@ -1,9 +1,11 @@
 import { defaultLogger } from 'shared/logger'
 import { ErrorContextTypes, ReportFatalErrorWithUnityPayloadAsync } from 'shared/loading/ReportFatalError'
 import { getUnityInstance, IUnityInterface } from './IUnityInterface'
+import future, { IFuture } from 'fp-future'
 
 export class ClientDebug {
   private unityInterface: IUnityInterface
+  private onDebugBridgeReady: IFuture<boolean> = future()
 
   public constructor(unityInterface: IUnityInterface) {
     this.unityInterface = unityInterface
@@ -83,6 +85,14 @@ export class ClientDebug {
 
   public ClearBots() {
     this.unityInterface.SendMessageToUnity('Main', 'ClearBots')
+  }
+
+  public SetDebugBridgeReady() {
+    this.onDebugBridgeReady.resolve(true)
+  }
+
+  public EnsureDebugBridgeReady(): IFuture<boolean> {
+    return this.onDebugBridgeReady
   }
 }
 

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -71,21 +71,25 @@ export async function initializeEngine(_gameInstance: UnityGame): Promise<void> 
 
   getUnityInstance().SetKernelConfiguration(kernelConfigForRenderer())
 
-  if (DEBUG) {
-    getUnityInstance().SetDebug()
-  }
-
-  if (SCENE_DEBUG_PANEL) {
-    getUnityInstance().SetSceneDebugPanel()
-  }
-
-  if (SHOW_FPS_COUNTER) {
-    getUnityInstance().ShowFPSPanel()
-  }
-
-  if (ENGINE_DEBUG_PANEL) {
-    getUnityInstance().SetEngineDebugPanel()
-  }
+  // Renderer's receiver for these kind of messages is created at runtime
+  // so we should wait until renderer notify us that the receiver is up and ready
+  clientDebug.EnsureDebugBridgeReady().then($ => {
+    if (DEBUG) {
+      getUnityInstance().SetDebug()
+    }
+  
+    if (SCENE_DEBUG_PANEL) {
+      getUnityInstance().SetSceneDebugPanel()
+    }
+  
+    if (SHOW_FPS_COUNTER) {
+      getUnityInstance().ShowFPSPanel()
+    }
+  
+    if (ENGINE_DEBUG_PANEL) {
+      getUnityInstance().SetEngineDebugPanel()
+    }
+  }).catch()
 
   observeLoadingStateChange(() => {
     setLoadingScreenBasedOnState()


### PR DESCRIPTION
Unity's receiver for debug messages is created at runtime, so we should wait until unity notify us that the receiver is up and ready