### PR TITLE
fix: test-scenes not loading

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -203,7 +203,8 @@ export function getTLD() {
 }
 
 export const WITH_FIXED_COLLECTIONS = (qs.WITH_COLLECTIONS && ensureSingleString(qs.WITH_COLLECTIONS)) || ''
-export const ENABLE_EMPTY_SCENES = !DEBUG || knownTLDs.includes(getTLD())
+export const ENABLE_EMPTY_SCENES = !location.search.includes('DISABLE_EMPTY_SCENES')
+export const ENABLE_TEST_SCENES = location.search.includes('ENABLE_TEST_SCENES')
 
 export function getAssetBundlesBaseUrl(network: ETHEREUM_NETWORK): string {
   const state = store.getState()

--- a/packages/decentraland-loader/lifecycle/manager.ts
+++ b/packages/decentraland-loader/lifecycle/manager.ts
@@ -9,12 +9,14 @@ import { WebWorkerTransport } from 'decentraland-rpc/lib/common/transports/WebWo
 import { ensureMetaConfigurationInitialized } from 'shared/meta'
 import { getResourcesURL } from 'shared/location'
 
-import { parcelLimits, ENABLE_EMPTY_SCENES, LOS, getAssetBundlesBaseUrl } from 'config'
+import { parcelLimits, ENABLE_EMPTY_SCENES, LOS, getAssetBundlesBaseUrl, ENABLE_TEST_SCENES } from 'config'
 
 import { ILand } from 'shared/types'
 import { getFetchContentServer, getCatalystServer, getSelectedNetwork } from 'shared/dao/selectors'
 import defaultLogger from 'shared/logger'
 import { store } from 'shared/store/isolatedStore'
+
+import { resolveUrl } from 'atomicHelpers/parseUrl'
 
 declare const globalThis: { workerManager: LifecycleManager }
 
@@ -122,10 +124,11 @@ export async function initParcelSceneWorker() {
   const state = store.getState()
 
   const fullRootUrl = getResourcesURL('.')
+  const localServer = resolveUrl(`${location.protocol}//${location.hostname}:${8080}`, '/local-ipfs')
 
   server.notify('Lifecycle.initialize', {
-    contentServer: getFetchContentServer(state),
-    catalystServer: getCatalystServer(state),
+    contentServer: ENABLE_TEST_SCENES ? localServer : getFetchContentServer(state),
+    catalystServer: ENABLE_TEST_SCENES ? localServer : getCatalystServer(state),
     contentServerBundles: getAssetBundlesBaseUrl(getSelectedNetwork(state)) + '/',
     rootUrl: fullRootUrl,
     lineOfSightRadius: LOS ? Number.parseInt(LOS, 10) : parcelLimits.visibleRadius,


### PR DESCRIPTION
re-enable test-scenes for debugging.
using url param `ENABLE_TEST_SCENES`
also added url param `DISABLE_EMPTY_SCENES` to avoid loading empty-parcels (mostly for debugging porpoises)