### PR TITLE
feat: kernel will try to reconnect websocket for ever the first time …

### DIFF
--- a/packages/unity-interface/wsEditorAdapter.ts
+++ b/packages/unity-interface/wsEditorAdapter.ts
@@ -14,62 +14,77 @@ export async function initializeUnityEditor(
 ): Promise<UnityGame> {
   const engineStartedFuture = future<UnityGame>()
 
-  logger.info(`Connecting WS to ${webSocketUrl}`)
-  container.innerHTML = `<h3>Connecting...</h3>`
-  const ws = new WebSocket(webSocketUrl)
+  let firstConnect = true
 
-  ws.onclose = function (e) {
-    logger.error('WS closed!', e)
-    container.innerHTML = `<h3 style='color:red'>Disconnected</h3>`
-  }
+  const connect = () => {
+    logger.info(`Connecting WS to ${webSocketUrl}`)
+    container.innerHTML = `<h3>Connecting...</h3>`
+    const ws = new WebSocket(webSocketUrl)
 
-  ws.onerror = function (e) {
-    logger.error('WS error!', e)
-    container.innerHTML = `<h3 style='color:red'>EERRORR</h3>`
-    engineStartedFuture.reject(new Error('Error in transport'))
-  }
-
-  ws.onmessage = function (ev) {
-    if (DEBUG_MESSAGES) {
-      logger.info('>>>', ev.data)
+    ws.onclose = function (e) {
+      if (firstConnect === false) {
+        logger.error('WS closed!', e)
+        container.innerHTML = `<h3 style='color:red'>Disconnected</h3>`
+      }
     }
 
-    try {
-      const m = JSON.parse(ev.data)
-      if (m.type && m.payload) {
-        options.onMessage(m.type, m.payload)
+    ws.onerror = function (e) {
+      if (firstConnect) {
+        setTimeout(function() {
+            connect();
+          }, 1000)
       } else {
-        logger.error('Unexpected message: ', m)
+        logger.error('WS error!', e)
+        container.innerHTML = `<h3 style='color:red'>EERRORR</h3>`
+        engineStartedFuture.reject(new Error('Error in transport'))
       }
-    } catch (e) {
-      logger.error(e)
+    }
+
+    ws.onmessage = function (ev) {
+      if (DEBUG_MESSAGES) {
+        logger.info('>>>', ev.data)
+      }
+
+      try {
+        const m = JSON.parse(ev.data)
+        if (m.type && m.payload) {
+          options.onMessage(m.type, m.payload)
+        } else {
+          logger.error('Unexpected message: ', m)
+        }
+      } catch (e) {
+        logger.error(e)
+      }
+    }
+
+    const gameInstance: UnityGame = {
+      Module: {},
+      SendMessage(_obj, type, payload) {
+        if (ws.readyState === ws.OPEN) {
+          const msg = JSON.stringify({ type, payload })
+          ws.send(msg)
+        }
+      },
+      SetFullscreen() {
+        // stub
+      },
+      async Quit() {
+        // stub
+      }
+    }
+
+    ws.onopen = function () {
+      firstConnect = false
+      container.classList.remove('dcl-loading')
+      logger.info('WS open!')
+      gameInstance.SendMessage('', 'Reset', '')
+      container.innerHTML = `<h3  style='color:green'>Connected</h3>`
+      // @see packages/shared/renderer/sagas.ts
+      engineStartedFuture.resolve(gameInstance)
     }
   }
 
-  const gameInstance: UnityGame = {
-    Module: {},
-    SendMessage(_obj, type, payload) {
-      if (ws.readyState === ws.OPEN) {
-        const msg = JSON.stringify({ type, payload })
-        ws.send(msg)
-      }
-    },
-    SetFullscreen() {
-      // stub
-    },
-    async Quit() {
-      // stub
-    }
-  }
-
-  ws.onopen = function () {
-    container.classList.remove('dcl-loading')
-    logger.info('WS open!')
-    gameInstance.SendMessage('', 'Reset', '')
-    container.innerHTML = `<h3  style='color:green'>Connected</h3>`
-    // @see packages/shared/renderer/sagas.ts
-    engineStartedFuture.resolve(gameInstance)
-  }
+  connect()
 
   return engineStartedFuture
 }


### PR DESCRIPTION
…until it connect

# What? <!-- what is this PR? -->
WebSocket will reconnect until it connect the first time

# Why? <!-- Explain the reason -->
In the `explorer-desktop` project, we open the process after the kernel, so we need a way to try connect until the `unity-renderer` websocket server listen.
