### PR TITLE
feat: Add feature flag for ExploreV2

### DIFF
--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -38,7 +38,7 @@ import { getSelectedNetwork } from 'shared/dao/selectors'
 
 const logger = createLogger('kernel: ')
 
-function configureTaskbarDependentHUD(i: IUnityInterface, voiceChatEnabled: boolean, builderInWorldEnabled: boolean) {
+function configureTaskbarDependentHUD(i: IUnityInterface, voiceChatEnabled: boolean, builderInWorldEnabled: boolean, exploreV2Enables: boolean) {
   // The elements below, require the taskbar to be active before being activated.
 
   i.ConfigureHUDElement(
@@ -52,7 +52,7 @@ function configureTaskbarDependentHUD(i: IUnityInterface, voiceChatEnabled: bool
   i.ConfigureHUDElement(HUDElementID.WORLD_CHAT_WINDOW, { active: true, visible: true })
 
   i.ConfigureHUDElement(HUDElementID.CONTROLS_HUD, { active: true, visible: false })
-  i.ConfigureHUDElement(HUDElementID.EXPLORE_HUD, { active: true, visible: false })
+  i.ConfigureHUDElement(HUDElementID.EXPLORE_HUD, { active: !exploreV2Enables, visible: false })
   i.ConfigureHUDElement(HUDElementID.HELP_AND_SUPPORT_HUD, { active: true, visible: false })
   i.ConfigureHUDElement(HUDElementID.BUILDER_PROJECTS_PANEL, { active: builderInWorldEnabled, visible: false })
 }
@@ -215,16 +215,17 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
       const identity = getCurrentIdentity(store.getState())!
 
       const VOICE_CHAT_ENABLED = true
-      const BUILDER_IN_WORLD_ENABLED =
-        identity.hasConnectedWeb3 && isFeatureEnabled(store.getState(), FeatureFlags.BUILDER_IN_WORLD, false)
+      const BUILDER_IN_WORLD_ENABLED = identity.hasConnectedWeb3 && isFeatureEnabled(store.getState(), FeatureFlags.BUILDER_IN_WORLD, false)
+      const EXPLORE_V2_ENABLED = isFeatureEnabled(store.getState(), FeatureFlags.EXPLORE_V2_ENABLED, false)
 
       const configForRenderer = kernelConfigForRenderer()
       configForRenderer.comms.voiceChatEnabled = VOICE_CHAT_ENABLED
       configForRenderer.features.enableBuilderInWorld = BUILDER_IN_WORLD_ENABLED
+      configForRenderer.features.enableExploreV2 = EXPLORE_V2_ENABLED
       configForRenderer.network = getSelectedNetwork(store.getState())
       i.SetKernelConfiguration(configForRenderer)
 
-      configureTaskbarDependentHUD(i, VOICE_CHAT_ENABLED, BUILDER_IN_WORLD_ENABLED)
+      configureTaskbarDependentHUD(i, VOICE_CHAT_ENABLED, BUILDER_IN_WORLD_ENABLED, EXPLORE_V2_ENABLED)
 
       i.ConfigureHUDElement(HUDElementID.PROFILE_HUD, { active: true, visible: true })
       i.ConfigureHUDElement(HUDElementID.USERS_AROUND_LIST_HUD, { active: VOICE_CHAT_ENABLED, visible: false })
@@ -250,7 +251,7 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
     })
     .catch((e) => {
       logger.error('error on configuring taskbar & friends hud / tutorial. Trying to default to simple taskbar', e)
-      configureTaskbarDependentHUD(i, false, false)
+      configureTaskbarDependentHUD(i, false, false, false)
     })
 
   startRealmsReportToRenderer()

--- a/packages/shared/meta/types.ts
+++ b/packages/shared/meta/types.ts
@@ -74,5 +74,6 @@ export enum FeatureFlags {
   QUESTS = 'quests',
   BUILDER_IN_WORLD = 'builder_in_world',
   AVATAR_LODS = 'avatar_lods',
-  ASSET_BUNDLES = 'asset_bundles'
+  ASSET_BUNDLES = 'asset_bundles',
+  EXPLORE_V2_ENABLED = 'explorev2'
 }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -579,6 +579,7 @@ export type KernelConfigForRenderer = {
   features: {
     enableBuilderInWorld: boolean
     enableAvatarLODs: boolean
+    enableExploreV2: boolean
   }
   gifSupported: boolean
   network: string

--- a/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/packages/unity-interface/kernelConfigForRenderer.ts
@@ -20,7 +20,8 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
     },
     features: {
       enableBuilderInWorld: false,
-      enableAvatarLODs: isFeatureEnabled(store.getState(), FeatureFlags.AVATAR_LODS, false)
+      enableAvatarLODs: isFeatureEnabled(store.getState(), FeatureFlags.AVATAR_LODS, false),
+      enableExploreV2: false
     },
     gifSupported:
       // tslint:disable-next-line


### PR DESCRIPTION
It adds the new feature flag `explorev2` that will be used by `unity-renderer` to enable/disable the new feature **[ExploreV2](https://www.notion.so/decentraland/PRD-Explore-V2-ab98e922c196488fb217596c888ce3d6)** (currently in development) and replace the old "**Explore & Play**" feature.