### PR TITLE
feat: add a default start position at open export.html file

### DIFF
--- a/static/export.html
+++ b/static/export.html
@@ -536,6 +536,13 @@
 
     <script>
       globalThis.preview = true
+
+      const qs = new URLSearchParams(document.location.search)
+      const position = qs.get('position') || qs.get('POSITION') || null
+      if (!position){
+        qs.append('position', '{{ scene.scene.base }}')
+        document.location.search = qs.toString()
+      }
     </script>
 
     <script src="./index.js"></script>


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Add a default position at open the html.

# Why? <!-- Explain the reason -->
It's neccesary to replace from setupExport of decentraland-ecs to real scene.json base position.
If the string `{{ scene.scene.base }}` isn't replaced to the x,y position, the kernel assign automatically 0,0 as now is doing.

https://github.com/decentraland/sdk/issues/84
https://github.com/decentraland/js-sdk-toolchain/pull/28