### PR TITLE
chore: Fixing double error handling so we can better report comms errors

### DIFF
--- a/packages/shared/comms/index.ts
+++ b/packages/shared/comms/index.ts
@@ -89,8 +89,7 @@ import {
   NEW_LOGIN,
   commsEstablished,
   COMMS_COULD_NOT_BE_ESTABLISHED,
-  commsErrorRetrying,
-  ESTABLISHING_COMMS
+  commsErrorRetrying
 } from 'shared/loading/types'
 import { getIdentity, getStoredSession } from 'shared/session'
 import { createLogger } from '../logger'
@@ -1057,7 +1056,7 @@ export async function connect(userId: string) {
         disconnect()
         defaultLogger.error(`error while trying to establish communications `, e)
         ReportFatalErrorWithCommsPayload(e, ErrorContext.COMMS_INIT)
-        BringDownClientAndShowError(ESTABLISHING_COMMS)
+        BringDownClientAndShowError(COMMS_COULD_NOT_BE_ESTABLISHED)
       })
 
     return context
@@ -1081,9 +1080,6 @@ export async function startCommunications(context: Context) {
         if (i >= maxAttemps) {
           // max number of attemps reached => rethrow error
           logger.info(`Max number of attemps reached (${maxAttemps}), unsuccessful connection`)
-          disconnect()
-          ReportFatalErrorWithCommsPayload(e, ErrorContext.COMMS_INIT)
-          BringDownClientAndShowError(COMMS_COULD_NOT_BE_ESTABLISHED)
           throw e
         } else {
           // max number of attempts not reached => continue with loop


### PR DESCRIPTION
We are reporting an error twice, and the second time it overrides the previous one, with something that's then reported incorrectly.

The error report that we are removing in this PR is then handled by this piece of code: https://github.com/decentraland/kernel/blob/5554c32bde2b54a0e966d30b98c3a1abc9282ce2/packages/shared/comms/index.ts#L1059

This will improve comms errors reporting, in conjunction with this other PR in website: https://github.com/decentraland/explorer-website/pull/76

![image](https://user-images.githubusercontent.com/2048532/135164103-5e42b614-6ff2-472e-860a-839e122c172e.png)
