### PR TITLE
feat: add new message for requesting headers for builder

### DIFF
--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -590,6 +590,17 @@ export class BrowserInterface {
     }
   }
 
+  public RequestHeaderForUrl(data: { method: string, url: string}) {
+    const identity = getCurrentIdentity(store.getState())
+    if (!identity) {
+      let emptyHeader: Record<string, string> = {}
+      getUnityInstance().SendBuilderCatalogHeaders(emptyHeader)
+    } else {
+      const headers = BuilderServerAPIManager.authorize(identity, data.method, data.url)
+      getUnityInstance().SendBuilderCatalogHeaders(headers)
+    }
+  }
+
   public RequestWearables(data: {
     filters: {
       ownedByUser: string | null


### PR DESCRIPTION
# What? 

This PR adds a new message for Unity to receive the requested headers for builder API.

It is generic enough to don't need more PRs if we want to add a new call

# Why? 

We need the headers of the builder API for a new call on Unity
