### PR TITLE
feat: Fetching ICE configuration from Catalyst

### DIFF
--- a/packages/atomicHelpers/signedFetch.ts
+++ b/packages/atomicHelpers/signedFetch.ts
@@ -1,0 +1,52 @@
+import { AuthChain, Authenticator, AuthIdentity } from "dcl-crypto"
+import { flatFetch, FlatFetchInit } from "./flatFetch"
+
+const AUTH_CHAIN_HEADER_PREFIX = 'x-identity-auth-chain-'
+const AUTH_TIMESTAMP_HEADER = 'x-identity-timestamp'
+const AUTH_METADATA_HEADER = 'x-identity-metadata'
+
+function getAuthHeaders(
+  method: string,
+  path: string,
+  metadata: Record<string, any>,
+  chainProvider: (payload: string) => AuthChain
+) {
+  const headers: Record<string, string> = {}
+  const timestamp = Date.now()
+  const metadataJSON = JSON.stringify(metadata)
+  const payloadParts = [method.toLowerCase(), path.toLowerCase(), timestamp.toString(), metadataJSON]
+  const payloadToSign = payloadParts.join(':').toLowerCase()
+
+  const chain = chainProvider(payloadToSign)
+
+  chain.forEach((link, index) => {
+    headers[`${AUTH_CHAIN_HEADER_PREFIX}${index}`] = JSON.stringify(link)
+  })
+
+  headers[AUTH_TIMESTAMP_HEADER] = timestamp.toString()
+  headers[AUTH_METADATA_HEADER] = metadataJSON
+
+  return headers
+}
+
+export function signedFetch(url: string, identity: AuthIdentity, init?: FlatFetchInit, additionalMetadata: Record<string, any> = {}) {
+  const path = new URL(url).pathname
+
+  const actualInit = {
+    ...init,
+    headers: {
+      ...getAuthHeaders(
+        init?.method ?? 'get',
+        path,
+        {
+          origin: location.origin,
+          ...additionalMetadata
+        },
+        (payload) => Authenticator.signPayload(identity, payload)
+      ),
+      ...init?.headers
+    }
+  } as FlatFetchInit
+
+  return flatFetch(url, actualInit)
+}

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -174,7 +174,7 @@ export namespace commConfigurations {
   export const iceServers = [
     { urls: 'stun:stun.l.google.com:19302' },
     {
-      urls: 'turn:137.184.103.20:3478',
+      urls: 'turn:coturn-raw.decentraland.services:3478',
       credential: 'passworddcl',
       username: 'usernamedcl'
     }

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -174,7 +174,7 @@ export namespace commConfigurations {
   export const iceServers = [
     { urls: 'stun:stun.l.google.com:19302' },
     {
-      urls: 'turn:stun.decentraland.org:3478',
+      urls: 'turn:137.184.103.20:3478',
       credential: 'passworddcl',
       username: 'usernamedcl'
     }

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -171,7 +171,7 @@ export namespace commConfigurations {
   export const autoChangeRealmInterval =
     typeof qs.AUTO_CHANGE_INTERVAL === 'string' ? parseInt(qs.AUTO_CHANGE_INTERVAL, 10) * 1000 : 40000
 
-  export const iceServers = [
+  export const defaultIceServers = [
     { urls: 'stun:stun.l.google.com:19302' },
     {
       urls: 'turn:coturn-raw.decentraland.services:3478',

--- a/packages/shared/apis/SignedFetch.ts
+++ b/packages/shared/apis/SignedFetch.ts
@@ -1,42 +1,13 @@
 import { ExposableAPI } from './ExposableAPI'
 import { exposeMethod, registerAPI } from 'decentraland-rpc/lib/host'
-import { AuthChain, Authenticator } from 'dcl-crypto'
 import { ParcelIdentity } from './ParcelIdentity'
-import { flatFetch, FlatFetchInit, FlatFetchResponse } from 'atomicHelpers/flatFetch'
+import { FlatFetchInit, FlatFetchResponse } from 'atomicHelpers/flatFetch'
+import { signedFetch } from 'atomicHelpers/signedFetch'
 import { ETHEREUM_NETWORK } from '../../config'
 import { getRealm, getSelectedNetwork } from 'shared/dao/selectors'
 import { store } from 'shared/store/isolatedStore'
 import { getIsGuestLogin } from 'shared/session/selectors'
 import { onLoginCompleted } from 'shared/session/sagas'
-
-const AUTH_CHAIN_HEADER_PREFIX = 'x-identity-auth-chain-'
-const AUTH_TIMESTAMP_HEADER = 'x-identity-timestamp'
-const AUTH_METADATA_HEADER = 'x-identity-metadata'
-
-function getAuthHeaders(
-  method: string,
-  path: string,
-  metadata: Record<string, any>,
-  chainProvider: (payload: string) => AuthChain
-) {
-  const headers: Record<string, string> = {}
-  const timestamp = Date.now()
-  const metadataJSON = JSON.stringify(metadata)
-  const payloadParts = [method.toLowerCase(), path.toLowerCase(), timestamp.toString(), metadataJSON]
-  const payloadToSign = payloadParts.join(':').toLowerCase()
-
-  const chain = chainProvider(payloadToSign)
-
-  chain.forEach((link, index) => {
-    headers[`${AUTH_CHAIN_HEADER_PREFIX}${index}`] = JSON.stringify(link)
-  })
-
-  headers[AUTH_TIMESTAMP_HEADER] = timestamp.toString()
-  headers[AUTH_METADATA_HEADER] = metadataJSON
-
-  return headers
-}
-
 @registerAPI('SignedFetch')
 export class SignedFetch extends ExposableAPI {
   parcelIdentity = this.options.getAPIInstance(ParcelIdentity)
@@ -49,29 +20,18 @@ export class SignedFetch extends ExposableAPI {
     const realm = getRealm(state)
     const isGuest = !!getIsGuestLogin(state)
     const network = getSelectedNetwork(state)
-    const path = new URL(url).pathname
-    const actualInit = {
-      ...init,
-      headers: {
-        ...getAuthHeaders(
-          init?.method ?? 'get',
-          path,
-          {
-            sceneId: this.parcelIdentity.cid,
-            parcel: this.getSceneData().scene.base,
-            // THIS WILL BE DEPRECATED
-            tld: network == ETHEREUM_NETWORK.MAINNET ? 'org' : 'zone',
-            network,
-            isGuest,
-            origin: location.origin,
-            realm: realm ? { ...realm, layer: realm.layer ?? '' } : undefined // If the realm doesn't have layer, we send it
-          },
-          (payload) => Authenticator.signPayload(identity!, payload)
-        ),
-        ...init?.headers
-      }
-    } as FlatFetchInit
-    return flatFetch(url, actualInit)
+
+    const additionalMetadata: Record<string, any> = {
+      sceneId: this.parcelIdentity.cid,
+      parcel: this.getSceneData().scene.base,
+      // THIS WILL BE DEPRECATED
+      tld: network == ETHEREUM_NETWORK.MAINNET ? 'org' : 'zone',
+      network,
+      isGuest,
+      realm: realm ? { ...realm, layer: realm.layer ?? '' } : undefined // If the realm doesn't have layer, we send it
+    }
+
+    return signedFetch(url, identity!, init, additionalMetadata)
   }
 
   private getSceneData() {

--- a/packages/shared/comms/index.ts
+++ b/packages/shared/comms/index.ts
@@ -103,7 +103,7 @@ import { sleep } from 'atomicHelpers/sleep'
 import { localProfileReceived } from 'shared/profiles/actions'
 import { getUnityInstance } from 'unity-interface/IUnityInterface'
 import { isURL } from 'atomicHelpers/isURL'
-import { RootCommsState, VoicePolicy } from './types'
+import { PeerParameters, RootCommsState, VoicePolicy } from './types'
 import { isFriend } from 'shared/friends/selectors'
 import { EncodedFrame } from 'voice-chat-codec/types'
 import Html from 'shared/Html'
@@ -111,6 +111,7 @@ import { isFeatureToggleEnabled } from 'shared/selectors'
 import * as qs from 'query-string'
 import { MinPeerData, Position3D } from '@dcl/catalyst-peer'
 import { BannedUsers } from 'shared/meta/types'
+import { signedFetch } from 'atomicHelpers/signedFetch'
 
 export type CommsVersion = 'v1' | 'v2'
 export type CommsMode = CommsV1Mode | CommsV2Mode
@@ -890,11 +891,33 @@ function subscribeToRealmChange(store: Store<RootState>) {
   )
 }
 
+async function getPeerParameters(): Promise<PeerParameters> {
+  const commsServer = getCommsServer(store.getState())
+
+  const defaultPeerParameters: PeerParameters = {
+    iceServers: commConfigurations.defaultIceServers
+  }
+
+  try {
+    const peerParameters = await signedFetch(`${commsServer}/peer-parameters`, getIdentity()!, { responseBodyType: 'json' })
+
+    if (peerParameters.ok) {
+      return { ...defaultPeerParameters, ...peerParameters.json }
+    } else {
+      throw new Error("Server response was not OK: " + peerParameters.status)
+    }
+  } catch (e) {
+    defaultLogger.warn("Couldn't fetch peer parameters for comms server. Using defaults!", e)
+    return defaultPeerParameters
+  }
+}
+
 let idTaken = false
 
 export async function connect(userId: string) {
   try {
     const user = await getStoredSession(userId)
+
     if (!user) {
       return undefined
     }
@@ -908,6 +931,8 @@ export async function connect(userId: string) {
     const [version, mode] = parseCommsMode(COMMS)
 
     idTaken = false
+
+    const peerParameters = await getPeerParameters()
 
     switch (version) {
       case 'v1': {
@@ -957,7 +982,7 @@ export async function connect(userId: string) {
 
         const peerConfig: LighthouseConnectionConfig = {
           connectionConfig: {
-            iceServers: commConfigurations.iceServers
+            iceServers: peerParameters.iceServers
           },
           authHandler: async (msg: string) => {
             try {

--- a/packages/shared/comms/types.ts
+++ b/packages/shared/comms/types.ts
@@ -15,3 +15,7 @@ export enum VoicePolicy {
   ALLOW_VERIFIED_ONLY,
   ALLOW_FRIENDS_ONLY
 }
+
+export type PeerParameters = {
+  iceServers: RTCIceServer[]
+}


### PR DESCRIPTION
This PR makes a request to the `peer-parameters` endpoint, which will respond with parameters corresponding to the current user.

Currently, it only responds ICE servers. We can use this to keep working on configuring turn server without needing to deploy new code.
