### PR TITLE
Message with unity renderer to update profile description

### DIFF
--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -309,6 +309,10 @@ export class BrowserInterface {
   public SaveUserUnverifiedName(changes: { newUnverifiedName: string }) {
     store.dispatch(saveProfileRequest({ unclaimedName: changes.newUnverifiedName }))
   }
+  
+  public SendSaveUserDescription(changes: { description: string }) {
+    store.dispatch(saveProfileRequest({ description: changes.description }))
+  }
 
   public CloseUserAvatar(isSignUpFlow = false) {
     if (isSignUpFlow) {


### PR DESCRIPTION
# What?
Message received from unity renderer to update the **profile description**.

# Why?
It is required in unity renderer to be able to update profile description from the profile menu.