### PR TITLE
fix: userId in comms context should be not nullable

### DIFF
--- a/packages/shared/comms/index.ts
+++ b/packages/shared/comms/index.ts
@@ -165,18 +165,15 @@ export class PeerTrackingInfo {
 
   public loadProfileIfNecessary(profileVersion: number) {
     if (this.identity && (profileVersion !== this.profilePromise.version || this.profilePromise.status === 'error')) {
-      if (!this.userInfo || !this.userInfo.userId) {
-        this.userInfo = {
-          ...(this.userInfo || {}),
-          userId: this.identity
-        }
+      if (!this.userInfo) {
+        this.userInfo = { userId: this.identity }
       }
       this.profilePromise = {
         promise: ProfileAsPromise(this.identity, profileVersion, this.profileType)
           .then((profile) => {
             const forRenderer = profileToRendererFormat(profile)
             this.lastProfileUpdate = new Date().getTime()
-            const userInfo = this.userInfo || {}
+            const userInfo = this.userInfo || { userId: this.identity } as UserInformation
             userInfo.version = profile.version
             this.userInfo = userInfo
             this.profilePromise.status = 'ok'
@@ -923,6 +920,7 @@ export async function connect(userId: string) {
     }
 
     const userInfo = {
+      userId,
       ...user
     }
 

--- a/packages/shared/comms/interface/index.ts
+++ b/packages/shared/comms/interface/index.ts
@@ -35,7 +35,7 @@ export interface WorldInstanceConnection {
 
   close(): void
 
-  sendInitialMessage(userInfo: Partial<UserInformation>): Promise<void>
+  sendInitialMessage(userInfo: UserInformation): Promise<void>
   sendProfileMessage(currentPosition: Position, userInfo: UserInformation): Promise<void>
   sendProfileRequest(currentPosition: Position, userId: string, version: number | undefined): Promise<void>
   sendProfileResponse(currentPosition: Position, profile: Profile): Promise<void>

--- a/packages/shared/comms/interface/types.ts
+++ b/packages/shared/comms/interface/types.ts
@@ -93,7 +93,7 @@ export type PeerInformation = {
 }
 
 export type UserInformation = {
-  userId?: string
+  userId: string
   version?: number
   pose?: Pose
   expression?: AvatarExpression

--- a/packages/shared/comms/peers.ts
+++ b/packages/shared/comms/peers.ts
@@ -12,7 +12,7 @@ export let localProfileUUID: UUID | null = null
 /**
  * @param uuid the UUID used by the communication engine
  */
-export function setLocalInformationForComms(uuid: UUID, user: UserInformation = {}) {
+export function setLocalInformationForComms(uuid: UUID, user: UserInformation) {
   if (typeof (uuid as any) !== 'string') throw new Error('Did not receive a valid UUID')
 
   if (localProfileUUID) {
@@ -101,10 +101,10 @@ export function setUpID(uuid: UUID): PeerInformation | null {
   return peer
 }
 
-export function receiveUserData(uuid: string, data: Partial<UserInformation>) {
+export function receiveUserData(uuid: string, data: UserInformation) {
   const peerData = setUpID(uuid)
   if (peerData) {
-    const userData = peerData.user || (peerData.user = peerData.user || {})
+    const userData = peerData.user || (peerData.user = peerData.user || { userId: uuid })
     const profileChanged = data.version && userData.version !== data.version
 
     if (profileChanged) {

--- a/packages/shared/comms/v2/LighthouseWorldInstanceConnection.ts
+++ b/packages/shared/comms/v2/LighthouseWorldInstanceConnection.ts
@@ -169,8 +169,8 @@ export class LighthouseWorldInstanceConnection implements WorldInstanceConnectio
     }
   }
 
-  async sendInitialMessage(userInfo: Partial<UserInformation>) {
-    const topic = userInfo.userId!
+  async sendInitialMessage(userInfo: UserInformation) {
+    const topic = userInfo.userId
 
     await this.sendProfileData(userInfo, topic, 'initialProfile')
   }


### PR DESCRIPTION
Should solve #78.

We have seen that the issue manifests itself when the userId in comms context is not initialized correctly. There is no clear scenario in which this would happen. This is likely a race condition.

With this PR, we make userId in UserInformation not nullable. This should ensure that the condition that makes other people don't see you doesn't happen.

This is the safest solution for the time being. Something that we can ship in short term.

In the future, we should refactor comms in kernel. Reduce redundant information and review the flow of control and information. But that is quite risky to do short term, without a plan.

