### PR TITLE
refactor: adapt builder API to the new format

### DIFF
--- a/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -113,7 +113,7 @@ export class BuilderServerAPIManager {
       const response = await fetch(urlToFecth, params)
       const data = await response.json()
 
-      const manifest: BuilderManifest = data.data
+      const manifest: BuilderManifest = data
 
       // If this manifest contains assets, we add them so we don't need to fetch them
       if (manifest) this.addAssetsFromManifest(manifest)


### PR DESCRIPTION
# What? 

The builder API has changed the way we recover the manifest and we need to adapt the API to match the new format. It is not working right now
