### PR TITLE
fix: Added parameter to override signed path, since the server may be behind proxy

### DIFF
--- a/packages/atomicHelpers/flatFetch.ts
+++ b/packages/atomicHelpers/flatFetch.ts
@@ -11,12 +11,6 @@ export type BodyType = 'json' | 'text'
 
 export type FlatFetchInit = RequestInit & { responseBodyType?: BodyType }
 
-export type SignedFetchInit = FlatFetchInit & {
-  /** Overrides path in signature. To use when the requested service is behind a reverse proxy or something similar,
-   *  and the exposed path doesn't correspond with the server's internal path for the request */
-  pathToSignOverride?: string
-}
-
 export async function flatFetch(url: string, init?: FlatFetchInit): Promise<FlatFetchResponse> {
   const response = await fetch(url, init)
 

--- a/packages/atomicHelpers/flatFetch.ts
+++ b/packages/atomicHelpers/flatFetch.ts
@@ -11,6 +11,12 @@ export type BodyType = 'json' | 'text'
 
 export type FlatFetchInit = RequestInit & { responseBodyType?: BodyType }
 
+export type SignedFetchInit = FlatFetchInit & {
+  /** Overrides path in signature. To use when the requested service is behind a reverse proxy or something similar,
+   *  and the exposed path doesn't correspond with the server's internal path for the request */
+  pathToSignOverride?: string
+}
+
 export async function flatFetch(url: string, init?: FlatFetchInit): Promise<FlatFetchResponse> {
   const response = await fetch(url, init)
 

--- a/packages/atomicHelpers/signedFetch.ts
+++ b/packages/atomicHelpers/signedFetch.ts
@@ -1,5 +1,11 @@
 import { AuthChain, Authenticator, AuthIdentity } from "dcl-crypto"
-import { flatFetch, FlatFetchInit, SignedFetchInit } from "./flatFetch"
+import { flatFetch, FlatFetchInit } from "./flatFetch"
+
+export type SignedFetchInit = FlatFetchInit & {
+  /** Overrides path in signature. To use when the requested service is behind a reverse proxy or something similar,
+   *  and the exposed path doesn't correspond with the server's internal path for the request */
+  pathToSignOverride?: string
+}
 
 const AUTH_CHAIN_HEADER_PREFIX = 'x-identity-auth-chain-'
 const AUTH_TIMESTAMP_HEADER = 'x-identity-timestamp'

--- a/packages/atomicHelpers/signedFetch.ts
+++ b/packages/atomicHelpers/signedFetch.ts
@@ -1,5 +1,5 @@
 import { AuthChain, Authenticator, AuthIdentity } from "dcl-crypto"
-import { flatFetch, FlatFetchInit } from "./flatFetch"
+import { flatFetch, FlatFetchInit, SignedFetchInit } from "./flatFetch"
 
 const AUTH_CHAIN_HEADER_PREFIX = 'x-identity-auth-chain-'
 const AUTH_TIMESTAMP_HEADER = 'x-identity-timestamp'
@@ -29,8 +29,8 @@ function getAuthHeaders(
   return headers
 }
 
-export function signedFetch(url: string, identity: AuthIdentity, init?: FlatFetchInit, additionalMetadata: Record<string, any> = {}) {
-  const path = new URL(url).pathname
+export function signedFetch(url: string, identity: AuthIdentity, init?: SignedFetchInit, additionalMetadata: Record<string, any> = {}) {
+  const path = init?.pathToSignOverride ?? new URL(url).pathname
 
   const actualInit = {
     ...init,

--- a/packages/shared/comms/index.ts
+++ b/packages/shared/comms/index.ts
@@ -896,7 +896,7 @@ async function getPeerParameters(): Promise<PeerParameters> {
   }
 
   try {
-    const peerParameters = await signedFetch(`${commsServer}/peer-parameters`, getIdentity()!, { responseBodyType: 'json' })
+    const peerParameters = await signedFetch(`${commsServer}/peer-parameters`, getIdentity()!, { pathToSignOverride: '/peer-parameters', responseBodyType: 'json' })
 
     if (peerParameters.ok) {
       return { ...defaultPeerParameters, ...peerParameters.json }


### PR DESCRIPTION
This fixes the request to comms/peer-parameters, which is currently responding with 401
