### PR TITLE
fix: avoid extra request on friend request

### DIFF
--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -69,6 +69,7 @@ import { renderStateObservable } from 'shared/world/worldState'
 import { realmToString } from 'shared/dao/utils/realmToString'
 import { store } from 'shared/store/isolatedStore'
 import { signalRendererInitializedCorrectly } from 'shared/renderer/actions'
+import { isAddress } from "eth-connect"
 
 declare const globalThis: { gifProcessor?: GIFProcessor }
 export let futures: Record<string, IFuture<any>> = {}
@@ -449,9 +450,10 @@ export class BrowserInterface {
     // TODO - fix this hack: search should come from another message and method should only exec correct updates (userId, action) - moliva - 01/05/2020
     if (action === FriendshipAction.REQUESTED_TO) {
       await ensureFriendProfile(userId)
-      found = hasConnectedWeb3(state, userId)
       
-      if (!found) {
+      if (isAddress(userId)) {
+        found = hasConnectedWeb3(state, userId)  
+      } else {
         let profileByName = findProfileByName(state, userId)
         if (profileByName) {
           userId = profileByName.userId


### PR DESCRIPTION
# What?

Its an improvement to avoid doing an extra user request when the requested friend is a user's name instead of an address.

# Why?

This is an approach to follow a [requested change](https://github.com/decentraland/kernel/pull/88#pullrequestreview-783625339) from a previous [PR #88](https://github.com/decentraland/kernel/pull/88). Using `UsersSearcher` as mentioned, retrieved no profiles when asking by user name, so the solution converged in this fix.