### PR TITLE
feat: [Explore V2] Signed requests to Events API (Kernel side)

### DIFF
--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -674,8 +674,8 @@ export class BrowserInterface {
   }
 
   public async RequestDCLEvents(urlPayload: { value: string }) {
-    var eventListPayload = null
-    var isOk = false
+    let eventListPayload = null
+    let isOk = false
 
     try {
       const identity = getIdentity()
@@ -692,8 +692,7 @@ export class BrowserInterface {
       } else {
         eventListPayload = requestResult.text
       }
-    }
-    catch (e) {
+    } catch (e) {
       defaultLogger.warn("Couldn't fetch DCL Events!", e)
       isOk = false
       eventListPayload = e.message

--- a/packages/unity-interface/IUnityInterface.ts
+++ b/packages/unity-interface/IUnityInterface.ts
@@ -176,5 +176,12 @@ export interface IUnityInterface {
   ResetBuilderScene(): void
   OnBuilderKeyDown(key: string): void
   SetBuilderConfiguration(config: BuilderConfiguration): void
+
+  // *********************************************************************************
+  // ************** DCL Events messages **************
+  // *********************************************************************************
+
+  SendDCLEvents(isOk: boolean, eventListPayload: string): void
+
   SendMessageToUnity(object: string, method: string, payload?: any): void
 }

--- a/packages/unity-interface/UnityInterface.ts
+++ b/packages/unity-interface/UnityInterface.ts
@@ -547,6 +547,14 @@ export class UnityInterface implements IUnityInterface {
     this.SendBuilderMessage('SetBuilderConfiguration', JSON.stringify(config))
   }
 
+  // *********************************************************************************
+  // ************** DCL Events messages **************
+  // *********************************************************************************
+
+  SendDCLEvents(isOk: boolean, eventListPayload: string) {
+    this.SendMessageToUnity('Bridges', 'DCLEvents', JSON.stringify({ ok: isOk, data: eventListPayload }))
+  }
+
   // NOTE: we override wasm's setThrew function before sending message to unity and restore it to it's
   // original function after message is sent. If an exception is thrown during SendMessage we assume that it's related
   // to the code executed by the SendMessage on unity's side.


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Make signed requests (through `signedFetch`) to the Events API.

# Why? <!-- Explain the reason -->
Once the new version of the Events API is available, we will need to sign the requests in order to be able to obtain custom user fields like `attending`  that will inform us if out user is subscribed to an event or not.