### PR TITLE
fix: web3 wearables in preview mode

### DIFF
--- a/packages/shared/profiles/sagas.ts
+++ b/packages/shared/profiles/sagas.ts
@@ -2,7 +2,7 @@ import { EntityType, Hashing, Fetcher } from 'dcl-catalyst-commons'
 import { ContentClient, DeploymentData } from 'dcl-catalyst-client'
 import { call, throttle, put, select, takeEvery } from 'redux-saga/effects'
 
-import { getServerConfigurations, ethereumConfigurations, RESET_TUTORIAL, ETHEREUM_NETWORK } from 'config'
+import { getServerConfigurations, ethereumConfigurations, RESET_TUTORIAL, ETHEREUM_NETWORK, PREVIEW } from 'config'
 
 import defaultLogger from 'shared/logger'
 import {
@@ -195,7 +195,7 @@ export function* handleFetchProfile(action: ProfileRequestAction): any {
   let profile: ServerFormatProfile | null = null
   let hasConnectedWeb3 = false
   try {
-    if (profileType === ProfileType.LOCAL && currentId !== userId) {
+    if ((PREVIEW || profileType === ProfileType.LOCAL) && currentId !== userId) {
       const peerProfile: Profile = yield call(requestLocalProfileToPeers, userId)
       if (peerProfile) {
         profile = ensureServerFormat(peerProfile)


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Force to request the profile to peers if you are in preview mode.

# Why? <!-- Explain the reason -->
If you use preview wearables that aren't deploy in any catalyst, kernel ignores.

This is the web3 profile wearing a preview wearable:
![web3-using-wearable](https://user-images.githubusercontent.com/8042536/141977704-cec43a95-45c9-48ec-9b63-632666d5e06a.png)

If you are next to the web3 profile you see this:
![unfixed](https://user-images.githubusercontent.com/8042536/141977698-a2225924-3a29-4047-bda0-0bd2f654f0da.png)

With the fix:
![fixed](https://user-images.githubusercontent.com/8042536/141977709-2e519408-647d-48db-84c0-6ef939479436.png)


