### PR TITLE
fix: WITH_COLLECTIONS query param base wearables fetch

### DIFF
--- a/packages/shared/catalogs/sagas.ts
+++ b/packages/shared/catalogs/sagas.ts
@@ -36,7 +36,6 @@ import { getCatalystServer, getFetchContentServer, getSelectedNetwork } from 'sh
 import { BuilderServerAPIManager } from 'shared/apis/SceneStateStorageController/BuilderServerAPIManager'
 import { getCurrentIdentity } from 'shared/session/selectors'
 import { getUnityInstance } from 'unity-interface/IUnityInterface'
-import { onLoginCompleted } from 'shared/session/sagas'
 import { ExplorerIdentity } from 'shared/session/types'
 
 export const BASE_AVATARS_COLLECTION_ID = 'urn:decentraland:off-chain:base-avatars'
@@ -109,9 +108,8 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
 
       // Fetch unpublished collections from builder server
       const uuidCollections = collectionIds.filter((collectionId) => !collectionId.startsWith('urn'))
-      if (uuidCollections.length > 0) {
-        yield onLoginCompleted()
-        const identity: ExplorerIdentity = yield select(getCurrentIdentity)
+      const identity: ExplorerIdentity = yield select(getCurrentIdentity)
+      if (uuidCollections.length > 0 && identity) {
         const v2Wearables: PartialWearableV2[] = yield call(
           fetchWearablesByCollectionFromBuilder,
           uuidCollections,
@@ -142,9 +140,8 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
       const uuidCollections = WITH_FIXED_COLLECTIONS.split(',').filter(
         (collectionId) => !collectionId.startsWith('urn')
       )
-      if (uuidCollections.length > 0) {
-        yield onLoginCompleted()
-        const identity: ExplorerIdentity = yield select(getCurrentIdentity)
+      const identity: ExplorerIdentity = yield select(getCurrentIdentity)
+      if (uuidCollections.length > 0 && identity) {
         const v2Wearables: PartialWearableV2[] = yield call(
           fetchWearablesByCollectionFromBuilder,
           uuidCollections,


### PR DESCRIPTION
### WHY
When opening the client with `WITH_COLLECTIONS` query param, if the user doesn't have a profile yet, the wearables request will wait forever.

When that happens the UX is as follows:
1. When entering as an incognito guest the backpack is the first thing you see to create the character
2. The backpack appears totally empty (no base wearables either)
3. After several wearables requests retries from the client (45 secs) the explorer crashes

Issue solved by this PR: https://github.com/decentraland/unity-renderer/issues/1547

### WHAT
Removed unneeded yield that in some occasions breaks the base wearables fetch and thus the client explodes

### TEST
**Production (bugged)**
Enter this URL **in incognito + guest mode**: https://play.decentraland.zone/?&NETWORK=ropsten&WITH_COLLECTIONS=3062136a-065d-4d94-b28c-f57d6ef04860&island=I3jg&position=0%2C-1&realm=thor&DEBUG_MODE

**This PR (fixed)**
Enter this URL **in incognito + guest mode**: https://play.decentraland.zone/?kernel-branch=fix%2FWithCollectionsParamBaseWearablesFetch&NETWORK=ropsten&WITH_COLLECTIONS=3062136a-065d-4d94-b28c-f57d6ef04860&island=I3jg&position=0%2C-1&realm=thor&DEBUG_MODE