### PR TITLE
fix: manifest from coords load

### DIFF
--- a/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -124,11 +124,12 @@ export class BuilderServerAPIManager {
   ): Promise<BuilderManifest | undefined> {
     try {
       // Fetch builder manifest by lands coordinates
-      const queryParams = 'manifests?' + 'creation_coords_eq=' + land
+      const endpoint = 'manifests'
+      const queryParams = endpoint + '?creation_coords_eq=' + land
       const urlToFecth = `${this.baseUrl}/${queryParams}`
 
       let params: RequestInit = {
-        headers: BuilderServerAPIManager.authorize(identity, 'get', '/' + queryParams)
+        headers: BuilderServerAPIManager.authorize(identity, 'get', '/' + endpoint)
       }
 
       const response = await fetch(urlToFecth, params)


### PR DESCRIPTION
# What? 

This PR makes BIW able to recover the manifest by coords

# Why? 

When the sign of the headers changed in the builder API, we changed the normal manifest but we didn't change the manifest by coords, this PR changes it now
