### PR TITLE
fix: hasPermissions function when it's a portable experience.

### DIFF
--- a/packages/shared/apis/Permissions.ts
+++ b/packages/shared/apis/Permissions.ts
@@ -24,15 +24,17 @@ export class Permissions extends ExposableAPI {
     // Backward compatibility with parcel scene with 'requiredPermissions' in the scene.json
     //  Only the two permissions that start with ALLOW_TO_... can be conceed without user
     //  interaction
-    const json = this.parcelIdentity.land.sceneJsonData
-    const list = (json.requiredPermissions || []) as PermissionItem[]
+    if (this.parcelIdentity.land) {
+      const json = this.parcelIdentity.land.sceneJsonData
+      const list = (json?.requiredPermissions || []) as PermissionItem[]
 
-    if (
-      list.includes(test) &&
-      (test === PermissionItem.ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE ||
-        test === PermissionItem.ALLOW_TO_TRIGGER_AVATAR_EMOTE)
-    ) {
-      return true
+      if (
+        list.includes(test) &&
+        (test === PermissionItem.ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE ||
+          test === PermissionItem.ALLOW_TO_TRIGGER_AVATAR_EMOTE)
+      ) {
+        return true
+      }
     }
 
     return this.permissionGranted.includes(test)


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Add a vlidation for land

# Why? <!-- Explain the reason -->
Portable experience doesn't land attribute.
