### PR TITLE
Add filter to prevent selecting a catalyst without capacity

### DIFF
--- a/packages/shared/dao/index.ts
+++ b/packages/shared/dao/index.ts
@@ -173,7 +173,7 @@ export function commsStatusUrl(domain: string, includeLayers: boolean = false, i
 export async function fetchCatalystStatuses(nodes: { domain: string }[]) {
   const results: PingResult[] = await Promise.all(nodes.map((node) => ping(commsStatusUrl(node.domain, true, true))))
 
-  const realmsWithCapacity = results.filter(realm => (realm.result?.maxUsers ?? 0 ) > (realm.result?.usersCount ?? -1))
+  const realmsWithCapacity = results.filter(realm => (realm.result?.maxUsers ?? 0) > (realm.result?.usersCount ?? -1))
 
   return zip(nodes, realmsWithCapacity).reduce(
     (union: Candidate[], [{ domain }, { elapsed, result, status }]: [CatalystNode, PingResult]) => {

--- a/packages/shared/dao/index.ts
+++ b/packages/shared/dao/index.ts
@@ -173,7 +173,7 @@ export function commsStatusUrl(domain: string, includeLayers: boolean = false, i
 export async function fetchCatalystStatuses(nodes: { domain: string }[]) {
   const results: PingResult[] = await Promise.all(nodes.map((node) => ping(commsStatusUrl(node.domain, true, true))))
 
-  let realmsWithCapacity = results.filter(realm => (realm.result?.maxUsers ?? 0 ) > (realm.result?.usersCount ?? -1))
+  const realmsWithCapacity = results.filter(realm => (realm.result?.maxUsers ?? 0 ) > (realm.result?.usersCount ?? -1))
 
   return zip(nodes, realmsWithCapacity).reduce(
     (union: Candidate[], [{ domain }, { elapsed, result, status }]: [CatalystNode, PingResult]) => {

--- a/packages/shared/dao/index.ts
+++ b/packages/shared/dao/index.ts
@@ -173,7 +173,9 @@ export function commsStatusUrl(domain: string, includeLayers: boolean = false, i
 export async function fetchCatalystStatuses(nodes: { domain: string }[]) {
   const results: PingResult[] = await Promise.all(nodes.map((node) => ping(commsStatusUrl(node.domain, true, true))))
 
-  return zip(nodes, results).reduce(
+  let realmsWithCapacity = results.filter(realm => (realm.result?.maxUsers ?? 0 ) > (realm.result?.usersCount ?? -1))
+
+  return zip(nodes, realmsWithCapacity).reduce(
     (union: Candidate[], [{ domain }, { elapsed, result, status }]: [CatalystNode, PingResult]) => {
       function buildBaseCandidate() {
         return {

--- a/packages/shared/dao/index.ts
+++ b/packages/shared/dao/index.ts
@@ -173,7 +173,7 @@ export function commsStatusUrl(domain: string, includeLayers: boolean = false, i
 export async function fetchCatalystStatuses(nodes: { domain: string }[]) {
   const results: PingResult[] = await Promise.all(nodes.map((node) => ping(commsStatusUrl(node.domain, true, true))))
 
-  const realmsWithCapacity = results.filter(realm => (realm.result?.maxUsers ?? 0) > (realm.result?.usersCount ?? -1))
+  const realmsWithCapacity = results.filter((realm) => (realm.result?.maxUsers ?? 0) > (realm.result?.usersCount ?? -1))
 
   return zip(nodes, realmsWithCapacity).reduce(
     (union: Candidate[], [{ domain }, { elapsed, result, status }]: [CatalystNode, PingResult]) => {


### PR DESCRIPTION
# What? <!-- what is this PR? -->
This pr prevents selecting a catalyst that has a max concurrent users lower or equal to the user count

# Why? <!-- Explain the reason -->
When a catalyst is not able to accept new connections and an algorithm still picks it, the user experiences an error that's not solvable without refreshing, and in some cases, kernel was still selecting the same realm (for example when the algorithm is 100% load balancing)
