### PR TITLE
fix: report a wrong position after movePlayerTo is called.

### DIFF
--- a/packages/shared/apis/RestrictedActions.ts
+++ b/packages/shared/apis/RestrictedActions.ts
@@ -18,7 +18,7 @@ export class RestrictedActions extends RestrictedExposableAPI {
   parcelIdentity = this.options.getAPIInstance(ParcelIdentity)
 
   @exposeMethod
-  async movePlayerTo(newPosition: Vector3, cameraTarget?: Vector3): Promise<void> {
+  async movePlayerTo(newRelativePosition: Vector3, cameraTarget?: Vector3): Promise<void> {
     // checks permissions
     await this.assertHasPermissions([PermissionItem.ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE])
 
@@ -26,11 +26,13 @@ export class RestrictedActions extends RestrictedExposableAPI {
     const basePosition = new Vector3()
     gridToWorld(base.x, base.y, basePosition)
 
-    const position = basePosition.add(newPosition)
+    // newRelativePosition is the position relative to the scene in meters
+    // newAbsolutePosition is the absolute position in the world in meters
+    const newAbsolutePosition = basePosition.add(newRelativePosition)
 
     // validate new position is inside one of the scene's parcels
-    if (!this.isPositionValid(position)) {
-      defaultLogger.error('Error: Position is out of scene', position)
+    if (!this.isPositionValid(newAbsolutePosition)) {
+      defaultLogger.error('Error: Position is out of scene', newAbsolutePosition)
       return
     }
     if (!this.isPositionValid(lastPlayerPosition)) {
@@ -40,7 +42,7 @@ export class RestrictedActions extends RestrictedExposableAPI {
 
     getUnityInstance().Teleport(
       {
-        position,
+        position: newAbsolutePosition,
         cameraTarget: cameraTarget ? basePosition.add(cameraTarget) : undefined
       },
       false
@@ -49,7 +51,7 @@ export class RestrictedActions extends RestrictedExposableAPI {
     // Get ahead of the position report that will be done automatically later and report
     // position right now, also marked as an immediate update (last bool in Position structure)
     browserInterface.ReportPosition({
-      position,
+      position: newAbsolutePosition,
       rotation: Quaternion.Identity,
       immediate: true
     })

--- a/packages/shared/apis/RestrictedActions.ts
+++ b/packages/shared/apis/RestrictedActions.ts
@@ -49,7 +49,7 @@ export class RestrictedActions extends RestrictedExposableAPI {
     // Get ahead of the position report that will be done automatically later and report
     // position right now, also marked as an immediate update (last bool in Position structure)
     browserInterface.ReportPosition({
-      position: newPosition,
+      position,
       rotation: Quaternion.Identity,
       immediate: true
     })


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Change `newPosition` to `position`. NewPosition is the function argument, and position is the finally calculated position.

# Why? <!-- Explain the reason -->
Fix https://github.com/decentraland/sdk/issues/162
