### PR TITLE
fix: camara rotation reported by renderer

### DIFF
--- a/packages/shared/world/SceneSystemWorker.ts
+++ b/packages/shared/world/SceneSystemWorker.ts
@@ -103,12 +103,12 @@ export class SceneSystemWorker extends SceneWorker {
     }
 
     if (this.engineAPI && 'rotationChanged' in this.engineAPI.subscribedEvents) {
-      if (positionReport.quaternion && !this.lastSentRotation.equals(positionReport.quaternion)) {
+      if (positionReport.cameraQuaternion && !this.lastSentRotation.equals(positionReport.cameraQuaternion)) {
         this.engineAPI.sendSubscriptionEvent('rotationChanged', {
-          rotation: positionReport.rotation,
-          quaternion: positionReport.quaternion
+          rotation: positionReport.cameraEuler,
+          quaternion: positionReport.cameraQuaternion
         })
-        this.lastSentRotation.copyFrom(positionReport.quaternion)
+        this.lastSentRotation.copyFrom(positionReport.cameraQuaternion)
       }
     }
   }

--- a/packages/shared/world/positionThings.ts
+++ b/packages/shared/world/positionThings.ts
@@ -24,14 +24,18 @@ declare let history: any
 export type PositionReport = {
   /** Camera position, world space */
   position: EcsMathReadOnlyVector3
-  /** Camera rotation */
+  /** Avatar rotation */
   quaternion: EcsMathReadOnlyQuaternion
-  /** Camera rotation, euler from quaternion */
+  /** Avatar rotation, euler from quaternion */
   rotation: EcsMathReadOnlyVector3
   /** Camera height, relative to the feet of the avatar or ground */
   playerHeight: number
   /** Should this position be applied immediately */
   immediate: boolean
+  /** Camera rotation */
+  cameraQuaternion: EcsMathReadOnlyQuaternion
+  /** Camera rotation, euler from quaternion */
+  cameraEuler: EcsMathReadOnlyVector3
 }
 export type ParcelReport = {
   /** Parcel where the user was before */

--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -96,7 +96,9 @@ const positionEvent = {
   rotation: Vector3.Zero(),
   playerHeight: playerConfigurations.height,
   mousePosition: Vector3.Zero(),
-  immediate: false // By default the renderer lerps avatars position
+  immediate: false, // By default the renderer lerps avatars position
+  cameraQuaternion: Quaternion.Identity,
+  cameraEuler: Vector3.Zero()
 }
 
 type SystemInfoPayload = {
@@ -148,11 +150,16 @@ export class BrowserInterface {
     rotation: EcsMathReadOnlyQuaternion
     playerHeight?: number
     immediate?: boolean
+    cameraRotation?: EcsMathReadOnlyQuaternion
   }) {
     positionEvent.position.set(data.position.x, data.position.y, data.position.z)
     positionEvent.quaternion.set(data.rotation.x, data.rotation.y, data.rotation.z, data.rotation.w)
     positionEvent.rotation.copyFrom(positionEvent.quaternion.eulerAngles)
     positionEvent.playerHeight = data.playerHeight || playerConfigurations.height
+
+    const cameraQuaternion = data.cameraRotation ?? data.rotation
+    positionEvent.cameraQuaternion.set(cameraQuaternion.x, cameraQuaternion.y, cameraQuaternion.z, cameraQuaternion.w)
+    positionEvent.cameraEuler.copyFrom(positionEvent.cameraQuaternion.eulerAngles)
 
     // By default the renderer lerps avatars position
     positionEvent.immediate = false


### PR DESCRIPTION
Decoupled the rotation used for comms and the rotation that is reported to the sdk.
Since: 
*comms needs avatar rotation
*sdk needs camera rotation