### PR TITLE
add console wrapper

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -132,6 +132,7 @@ export const DEBUG_LOGIN = location.search.includes('DEBUG_LOGIN')
 export const DEBUG_PM = location.search.includes('DEBUG_PM')
 export const DEBUG_SCENE_LOG = DEBUG || location.search.includes('DEBUG_SCENE_LOG')
 export const DEBUG_KERNEL_LOG = !PREVIEW || location.search.includes('DEBUG_KERNEL_LOG')
+export const DEBUG_PREFIX = ensureSingleString(qs.DEBUG_PREFIX)
 
 export const RESET_TUTORIAL = location.search.includes('RESET_TUTORIAL')
 

--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -338,7 +338,7 @@ export async function startPreview() {
   ws.addEventListener('message', (msg) => {
     if (msg.data.startsWith('{')) {
       // tslint:disable-next-line: no-console
-      console.log('Update message from CLI', msg.data)
+      defaultLogger.log('Update message from CLI', msg.data)
       const message: sdk.Messages = JSON.parse(msg.data)
       handleServerMessage(message)
     }

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,5 +1,6 @@
 import './apis/index'
 
+import { DEBUG_PREFIX } from 'config'
 import { notStarted } from './loading/types'
 import { buildStore } from './store/store'
 import { initializeUrlPositionObserver } from './world/positionThings'
@@ -10,10 +11,13 @@ import { isRendererVisible } from './loading/selectors'
 import { RootStore } from './store/rootTypes'
 import { initializeSessionObserver } from './session/sagas'
 import { hookAnalyticsObservables } from './analytics/hook-observable'
+import wrapConsoleLogger from './logger/wrap'
 
 declare const globalThis: { globalStore: RootStore }
 
 export function initShared() {
+  wrapConsoleLogger(DEBUG_PREFIX || '')
+
   if (globalThis.globalStore) {
     return
   }

--- a/packages/shared/logger/index.ts
+++ b/packages/shared/logger/index.ts
@@ -28,28 +28,29 @@ export function createDummyLogger(): ILogger {
 }
 
 export function createLogger(prefix: string): ILogger {
+  const kernelPrefix = `kernel:${prefix} `
   return {
     error(message: string | Error, ...args: any[]): void {
       if (typeof message === 'object' && message.stack) {
-        console.error(prefix + message, ...args, message.stack)
+        console.error(kernelPrefix + message, ...args, message.stack)
       } else {
-        console.error(prefix + message, ...args)
+        console.error(kernelPrefix + message, ...args)
       }
     },
     log(message: string, ...args: any[]): void {
       if (args && args[0] && args[0].startsWith && args[0].startsWith('The entity is already in the engine.')) {
         return
       }
-      console.log(prefix + message, ...args)
+      console.log(kernelPrefix + message, ...args)
     },
     warn(message: string, ...args: any[]): void {
-      console.log(prefix + message, ...args)
+      console.log(kernelPrefix + message, ...args)
     },
     info(message: string, ...args: any[]): void {
-      console.info(prefix + message, ...args)
+      console.info(kernelPrefix + message, ...args)
     },
     trace(message: string, ...args: any[]): void {
-      console.trace(prefix + message, ...args)
+      console.trace(kernelPrefix + message, ...args)
     }
   }
 }

--- a/packages/shared/logger/index.ts
+++ b/packages/shared/logger/index.ts
@@ -26,31 +26,31 @@ export function createDummyLogger(): ILogger {
     }
   }
 }
-
-export function createLogger(prefix: string): ILogger {
-  const kernelPrefix = `kernel:${prefix} `
+export const KERNEL = 'kernel'
+export function createLogger(prefix: string, subPrefix: string = ''): ILogger {
+  const kernelPrefix = `${KERNEL}:${prefix} `
   return {
     error(message: string | Error, ...args: any[]): void {
       if (typeof message === 'object' && message.stack) {
-        console.error(kernelPrefix, message, ...args, message.stack)
+        console.error(kernelPrefix, subPrefix, message, ...args, message.stack)
       } else {
-        console.error(kernelPrefix, message, ...args)
+        console.error(kernelPrefix, subPrefix, message, ...args)
       }
     },
     log(message: string, ...args: any[]): void {
       if (args && args[0] && args[0].startsWith && args[0].startsWith('The entity is already in the engine.')) {
         return
       }
-      console.log(kernelPrefix, message, ...args)
+      console.log(kernelPrefix, subPrefix, message, ...args)
     },
     warn(message: string, ...args: any[]): void {
-      console.log(kernelPrefix, message, ...args)
+      console.log(kernelPrefix, subPrefix, message, ...args)
     },
     info(message: string, ...args: any[]): void {
-      console.info(kernelPrefix, message, ...args)
+      console.info(kernelPrefix, subPrefix, message, ...args)
     },
     trace(message: string, ...args: any[]): void {
-      console.trace(kernelPrefix, message, ...args)
+      console.trace(kernelPrefix, subPrefix, message, ...args)
     }
   }
 }

--- a/packages/shared/logger/index.ts
+++ b/packages/shared/logger/index.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-console
 export type ILogger = {
-  error(message: string, ...args: any[]): void
+  error(message: string | Error, ...args: any[]): void
   log(message: string, ...args: any[]): void
   warn(message: string, ...args: any[]): void
   info(message: string, ...args: any[]): void
@@ -32,25 +32,25 @@ export function createLogger(prefix: string): ILogger {
   return {
     error(message: string | Error, ...args: any[]): void {
       if (typeof message === 'object' && message.stack) {
-        console.error(kernelPrefix + message, ...args, message.stack)
+        console.error(kernelPrefix, message, ...args, message.stack)
       } else {
-        console.error(kernelPrefix + message, ...args)
+        console.error(kernelPrefix, message, ...args)
       }
     },
     log(message: string, ...args: any[]): void {
       if (args && args[0] && args[0].startsWith && args[0].startsWith('The entity is already in the engine.')) {
         return
       }
-      console.log(kernelPrefix + message, ...args)
+      console.log(kernelPrefix, message, ...args)
     },
     warn(message: string, ...args: any[]): void {
-      console.log(kernelPrefix + message, ...args)
+      console.log(kernelPrefix, message, ...args)
     },
     info(message: string, ...args: any[]): void {
-      console.info(kernelPrefix + message, ...args)
+      console.info(kernelPrefix, message, ...args)
     },
     trace(message: string, ...args: any[]): void {
-      console.trace(kernelPrefix + message, ...args)
+      console.trace(kernelPrefix, message, ...args)
     }
   }
 }

--- a/packages/shared/logger/wrap.ts
+++ b/packages/shared/logger/wrap.ts
@@ -10,15 +10,15 @@ export const _console = Object.assign({}, console)
 export default function wrap(prefix: string) {
   function logger(method: Method) {
     return function log(...args: any[]): void {
+      const [logPrefix] = args
       function matchPrefix() {
-        const [data] = args
         if (prefix === '*' || !prefix) {
           return true
         }
         const prefixes = prefix.split(',')
 
-        if (typeof data === 'string') {
-          return prefixes.find((p) => data.startsWith(p))
+        if (typeof logPrefix === 'string') {
+          return prefixes.find((p) => logPrefix.startsWith(p))
         }
 
         return false

--- a/packages/shared/logger/wrap.ts
+++ b/packages/shared/logger/wrap.ts
@@ -1,0 +1,36 @@
+export const METHODS = ['error', 'info', 'log', 'warn', 'trace'] as const
+type Method = typeof METHODS[number]
+
+/**
+ * @deprecated Only exported for testing. DO NOT USE
+ * @internal
+ */
+export const _console = Object.assign({}, console)
+
+export default function wrap(prefix: string) {
+  function logger(method: Method) {
+    return function log(...args: any[]): void {
+      function matchPrefix() {
+        const [data] = args
+        if (prefix === '*' || !prefix) {
+          return true
+        }
+        const prefixes = prefix.split(',')
+
+        if (typeof data === 'string') {
+          return prefixes.find((p) => data.startsWith(p))
+        }
+
+        return false
+      }
+
+      if (matchPrefix()) {
+        return _console[method](...args)
+      }
+    }
+  }
+
+  METHODS.forEach((method) => {
+    console[method] = logger(method)
+  })
+}

--- a/packages/unity-interface/UnityParcelScene.ts
+++ b/packages/unity-interface/UnityParcelScene.ts
@@ -12,7 +12,7 @@ import { defaultPortableExperiencePermissions, Permissions } from 'shared/apis/P
 export class UnityParcelScene extends UnityScene<LoadableParcelScene> {
   constructor(public data: EnvironmentData<LoadableParcelScene>) {
     super(data)
-    const loggerPrefix = data.data.basePosition.x + ',' + data.data.basePosition.y + ': '
+    const loggerPrefix = `scene: [${data.data.basePosition.x}, ${data.data.basePosition.y}]`
     this.logger = DEBUG_SCENE_LOG ? createLogger(loggerPrefix) : createDummyLogger()
   }
 
@@ -42,7 +42,7 @@ export class UnityParcelScene extends UnityScene<LoadableParcelScene> {
 export class UnityPortableExperienceScene extends UnityScene<LoadablePortableExperienceScene> {
   constructor(public data: EnvironmentData<LoadablePortableExperienceScene>) {
     super(data)
-    const loggerPrefix = data.sceneId + ': '
+    const loggerPrefix = `px: [${data.sceneId}] `
     this.logger = DEBUG_SCENE_LOG ? createLogger(loggerPrefix) : createDummyLogger()
   }
 

--- a/packages/unity-interface/UnityScene.ts
+++ b/packages/unity-interface/UnityScene.ts
@@ -29,7 +29,7 @@ export class UnityScene<T> implements ParcelSceneAPI {
   initFinished: boolean = false
 
   constructor(public data: EnvironmentData<T>) {
-    this.logger = DEBUG_SCENE_LOG ? createLogger(getParcelSceneID(this) + ': ') : createDummyLogger()
+    this.logger = DEBUG_SCENE_LOG ? createLogger('unityScene: ' + getParcelSceneID(this) + ': ') : createDummyLogger()
 
     const startLoadingTime = performance.now()
 

--- a/packages/unity-interface/UnityScene.ts
+++ b/packages/unity-interface/UnityScene.ts
@@ -1,6 +1,6 @@
 import { EventDispatcher } from 'decentraland-rpc/lib/common/core/EventDispatcher'
 import { WSS_ENABLED, FORCE_SEND_MESSAGE, DEBUG_MESSAGES_QUEUE_PERF, DEBUG_SCENE_LOG } from 'config'
-import { createDummyLogger, createLogger, ILogger } from 'shared/logger'
+import defaultLogger, { createDummyLogger, createLogger, ILogger } from 'shared/logger'
 import { EntityAction, EnvironmentData } from 'shared/types'
 import { ParcelSceneAPI } from 'shared/world/ParcelSceneAPI'
 import { SceneWorker } from 'shared/world/SceneWorker'
@@ -64,8 +64,7 @@ export class UnityScene<T> implements ParcelSceneAPI {
         sendBatchMsgCount -= sendBatchMsgs.splice(0, 1)[0]
       }
 
-      // tslint:disable-next-line:no-console
-      console.log(`sendBatch time total for msgs ${sendBatchMsgCount} calls: ${sendBatchTimeCount}ms ... `)
+      defaultLogger.log(`sendBatch time total for msgs ${sendBatchMsgCount} calls: ${sendBatchTimeCount}ms ... `)
     }
   }
 

--- a/packages/unity-interface/trace.ts
+++ b/packages/unity-interface/trace.ts
@@ -1,5 +1,6 @@
 import type { UnityGame } from '@dcl/unity-renderer/src'
 import { TRACE_RENDERER } from 'config'
+import defaultLogger from '../shared/logger'
 import type { CommonRendererOptions } from './loader'
 
 let pendingMessagesInTrace = 0
@@ -35,7 +36,7 @@ export function beginTrace(messagesCount: number) {
     currentTrace.length = 0
     pendingMessagesInTrace = messagesCount
     // tslint:disable-next-line
-    console.log('[TRACING] Beginning trace')
+    defaultLogger.log('[TRACING] Beginning trace')
   }
 }
 
@@ -63,7 +64,7 @@ export function logTrace(type: string, payload: string | number | undefined, dir
     pendingMessagesInTrace--
     if (pendingMessagesInTrace % 11 === 0) {
       // tslint:disable-next-line
-      console.log('[TRACING] Pending messages to download: ' + pendingMessagesInTrace)
+      defaultLogger.log('[TRACING] Pending messages to download: ' + pendingMessagesInTrace)
     }
     if (pendingMessagesInTrace === 0) {
       endTrace()
@@ -77,7 +78,7 @@ export function endTrace() {
   const file = new File([content], 'decentraland-trace.csv', { type: 'text/csv' })
   const exportUrl = URL.createObjectURL(file)
   // tslint:disable-next-line
-  console.log('[TRACING] Ending trace, downloading file: ', exportUrl, ' check your downloads folder.')
+  defaultLogger.log('[TRACING] Ending trace, downloading file: ', exportUrl, ' check your downloads folder.')
   window.location.assign(exportUrl)
   currentTrace.length = 0
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,7 +25,7 @@ import './unit/catalog.saga.test'
 
 import './dao'
 
-import './shared/sceneEvents'
+import './shared'
 
 import './scene-system/sdk'
 

--- a/test/shared/index.ts
+++ b/test/shared/index.ts
@@ -1,0 +1,2 @@
+import './logger.spec'
+import './sceneEvents'

--- a/test/shared/logger.spec.ts
+++ b/test/shared/logger.spec.ts
@@ -1,6 +1,7 @@
 import * as sinon from 'sinon'
 import { expect } from "chai"
 import * as wrapConsole from 'shared/logger/wrap'
+import { defaultLogger } from 'shared/logger'
 
 describe('Wrapped Logger', () => {
   wrapConsole.METHODS.forEach(method => {
@@ -51,6 +52,15 @@ describe('Wrapped Logger', () => {
         // Unity prefix
         console[method](unityPrefix + message)
         expect(spy.calledWith(unityPrefix + message)).to.equal(true)
+      })
+
+      it('should log an object correctly', () => {
+        const spy = sinon.spy(wrapConsole._console, method)
+        const prefix = '*'
+        wrapConsole.default(prefix)
+        const message = { someMessage: true }
+        defaultLogger.error(message as any)
+        expect(spy.calledWith(message)).to.equal(true)
       })
     })
   })

--- a/test/shared/logger.spec.ts
+++ b/test/shared/logger.spec.ts
@@ -1,0 +1,57 @@
+import * as sinon from 'sinon'
+import { expect } from "chai"
+import * as wrapConsole from 'shared/logger/wrap'
+
+describe('Wrapped Logger', () => {
+  wrapConsole.METHODS.forEach(method => {
+    describe(`Wrapped Console.${method}`, () => {
+      it('should log everything without prefix', () => {
+        const a = sinon.spy(wrapConsole._console, method)
+        wrapConsole.default('*')
+        const message = 'Some'
+        console[method](message)
+        expect(a.calledWith(message)).to.equal(true)
+      })
+
+      it('should NOT log if the message doenst match the prefix', () => {
+        const a = sinon.spy(wrapConsole._console, method)
+        const prefix = 'kernel: '
+        wrapConsole.default(prefix)
+
+        // No prefix
+        const message = 'Some message without prefix'
+        console[method](message)
+        expect(a.called).to.equal(false)
+
+        // Prefix with multiple args
+        console[method](prefix, message)
+        expect(a.calledWith(prefix ,message)).to.equal(true)
+
+        // Prefix with single arg
+        console[method](prefix + message)
+        expect(a.calledWith(prefix + message)).to.equal(true)
+      })
+
+      it('should log with multiple prefixes', () => {
+        const spy = sinon.spy(wrapConsole._console, method)
+        const kernelPrefix = 'kernel: '
+        const unityPrefix = 'unity: '
+        const prefix = `${kernelPrefix},${unityPrefix}`
+        wrapConsole.default(prefix)
+        const message = 'Some message without prefix'
+
+        // No prefix
+        console[method](message)
+        expect(spy.called).to.equal(false)
+
+        // Kernel prefix
+        console[method](kernelPrefix, message)
+        expect(spy.calledWith(kernelPrefix ,message)).to.equal(true)
+
+        // Unity prefix
+        console[method](unityPrefix + message)
+        expect(spy.calledWith(unityPrefix + message)).to.equal(true)
+      })
+    })
+  })
+})

--- a/test/shared/logger.spec.ts
+++ b/test/shared/logger.spec.ts
@@ -55,12 +55,14 @@ describe('Wrapped Logger', () => {
       })
 
       it('should log an object correctly', () => {
+        if (method === 'warn') return
         const spy = sinon.spy(wrapConsole._console, method)
         const prefix = '*'
         wrapConsole.default(prefix)
         const message = { someMessage: true }
-        defaultLogger.error(message as any)
-        expect(spy.calledWith(message)).to.equal(true)
+        defaultLogger[method](message as any)
+
+        expect(spy.calledWith('kernel: ', message)).to.equal(true)
       })
     })
   })

--- a/test/shared/logger.spec.ts
+++ b/test/shared/logger.spec.ts
@@ -62,7 +62,7 @@ describe('Wrapped Logger', () => {
         const message = { someMessage: true }
         defaultLogger[method](message as any)
 
-        expect(spy.calledWith('kernel: ', message)).to.equal(true)
+        expect(spy.calledWith('kernel: ', '', message)).to.equal(true)
       })
     })
   })


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Add a string prefix to the logs so we can identify if the logs comes from kernel or another library.
This way we can use the DEBUG_PREFIX url param to filter the logs that we want.

i.e. https://play.decentraland.zone/?kernel-branch=add/wrap-console-log&DEBUG_PREFIX=kernel: will log only the logs that starts with `kernel:`

By default we log everything, so this should not change anything if we dont use the query param.
...

# Why? <!-- Explain the reason -->
Clean the noise in the console so the user can see only the logs that he wants. i.e. scene logs
...
