### PR TITLE
feat: only show request web3 api use on require sign

### DIFF
--- a/packages/shared/apis/EthereumController.ts
+++ b/packages/shared/apis/EthereumController.ts
@@ -5,7 +5,8 @@ import {
   sendAsync,
   convertMessageToObject,
   signMessage,
-  messageToString
+  messageToString,
+  rpcRequireSign
 } from 'shared/ethereum/EthereumService'
 import { RPCSendableMessage } from 'shared/types'
 import { getUserAccount, requestManager } from 'shared/ethereum/provider'
@@ -84,10 +85,12 @@ export class EthereumController extends RestrictedExposableAPI implements IEther
   @exposeMethod
   async sendAsync(message: RPCSendableMessage): Promise<any> {
     await this.assertHasPermissions([PermissionItem.USE_WEB3_API])
-    await getUnityInstance().RequestWeb3ApiUse('sendAsync', {
-      message: `${message.method}(${message.params.join(',')})`,
-      sceneId: await this.parcelIdentity.getSceneId()
-    })
+    if (rpcRequireSign(message)) {
+      await getUnityInstance().RequestWeb3ApiUse('sendAsync', {
+        message: `${message.method}(${message.params.join(',')})`,
+        sceneId: await this.parcelIdentity.getSceneId()
+      })
+    }
     return sendAsync(message)
   }
 

--- a/packages/shared/ethereum/EthereumService.ts
+++ b/packages/shared/ethereum/EthereumService.ts
@@ -43,8 +43,14 @@ const whitelist = [
   'eth_getCode'
 ]
 
+const requireSign = ['eth_sendTransaction', 'eth_signTypedData_v4']
+
 function isWhitelistedRPC(msg: RPCSendableMessage) {
   return msg.method && whitelist.includes(msg.method)
+}
+
+export function rpcRequireSign(msg: RPCSendableMessage) {
+  return msg.method && requireSign.includes(msg.method)
 }
 
 export async function sendAsync(message: RPCSendableMessage): Promise<any> {


### PR DESCRIPTION
The pop up of the transaction is been sent even if not needed.

We must add a list of the methods that need user validation to fix it properly.