### PR TITLE
Add/fetch timeout

### DIFF
--- a/packages/scene-system/sdk/Fetch.ts
+++ b/packages/scene-system/sdk/Fetch.ts
@@ -30,13 +30,11 @@ export function createFetch({ canUseFetch, previewMode, log, originalFetch }: Fe
 
     async function fetchRequest() {
       const abortController = new AbortController()
-      const signal = abortController.signal
-      const TIMEOUT_LIMIT = 5000
+      const TIMEOUT_LIMIT = 30000
       const timeout = setTimeout(() => {
         abortController.abort()
       }, opts?.timeout || TIMEOUT_LIMIT)
-
-      const response = await originalFetch(resource, Object.assign({ signal, init }))
+      const response = await originalFetch(resource, { signal: abortController.signal, ...init })
       clearTimeout(timeout)
       return response
     }

--- a/packages/scene-system/sdk/Fetch.ts
+++ b/packages/scene-system/sdk/Fetch.ts
@@ -8,9 +8,13 @@ export interface FetchOptions {
   log(...a: any[]): void
 }
 
+type Opts = {
+  timeout?: number
+}
+
 export function createFetch({ canUseFetch, previewMode, log, originalFetch }: FetchOptions) {
   const fifoFetch = new PQueue({ concurrency: 1 })
-  return (resource: RequestInfo, init?: RequestInit | undefined): Promise<Response> => {
+  return (resource: RequestInfo, init?: RequestInit | undefined, opts?: Opts): Promise<Response> => {
     const url = resource instanceof Request ? resource.url : resource
     if (url.toLowerCase().substr(0, 8) !== 'https://') {
       if (previewMode) {
@@ -24,6 +28,19 @@ export function createFetch({ canUseFetch, previewMode, log, originalFetch }: Fe
       throw new Error("This scene doesn't have allowed to use fetch")
     }
 
-    return fifoFetch.add(() => originalFetch(resource, init))
+    async function fetchRequest() {
+      const abortController = new AbortController()
+      const signal = abortController.signal
+      const TIMEOUT_LIMIT = 5000
+      const timeout = setTimeout(() => {
+        abortController.abort()
+      }, opts?.timeout || TIMEOUT_LIMIT)
+
+      const response = await originalFetch(resource, Object.assign({ signal, init }))
+      clearTimeout(timeout)
+      return response
+    }
+
+    return fifoFetch.add(fetchRequest)
   }
 }

--- a/test/scene-system/sdk/fetchWrapper.spec.ts
+++ b/test/scene-system/sdk/fetchWrapper.spec.ts
@@ -110,7 +110,7 @@ describe('Fetch Wrapped for scenes' , () => {
     expect(error.name).to.eql('AbortError')
   })
 
-  it.only('should abort fetch if reaches the timeout opt', async () => {
+  it('should abort fetch if reaches the timeout opt', async () => {
     let error: Error = null
     let counter = 0
     await Promise.all([

--- a/test/scene-system/sdk/fetchWrapper.spec.ts
+++ b/test/scene-system/sdk/fetchWrapper.spec.ts
@@ -21,7 +21,7 @@ describe('Fetch Wrapped for scenes' , () => {
     canUseFetch: false, log, originalFetch, previewMode: false
   })
 
-  const timePerFetchSleep = 500
+  const timePerFetchSleep = 100
   const wrappedDelayFetch = createFetch({
     canUseFetch: true,
     log,
@@ -89,9 +89,8 @@ describe('Fetch Wrapped for scenes' , () => {
     let counter = 0
     const N = 10
     for (let i = 0; i < N; i++) {
-      wrappedDelayFetch('https://test.test/').then(response => response.text()).then(() => counter++)
+      wrappedDelayFetch('https://test.test/').then(() => counter++)
     }
-
     await sleep(timePerFetchSleep * 1.2)
     expect(counter).to.eql(1)
     await sleep(timePerFetchSleep * 2)
@@ -114,7 +113,7 @@ describe('Fetch Wrapped for scenes' , () => {
     let error: Error = null
     let counter = 0
     await Promise.all([
-      wrappedDelayFetch('https://test.test/', {}, { timeout: 100 }).catch(err => {
+      wrappedDelayFetch('https://test.test/', {}, { timeout: 5 }).catch(err => {
         error = err
         counter++
       }),

--- a/test/scene-system/sdk/index.ts
+++ b/test/scene-system/sdk/index.ts
@@ -1,1 +1,2 @@
-import './usingFetchAndWebsocket.spec'
+import './websocketWrapper.spec'
+import './fetchWrapper.spec'

--- a/test/scene-system/sdk/websocketWrapper.spec.ts
+++ b/test/scene-system/sdk/websocketWrapper.spec.ts
@@ -1,0 +1,71 @@
+import * as sinon from 'sinon'
+import { createWebSocket } from '../../../packages/scene-system/sdk/WebSocket'
+
+class FakeWebSocket {
+  constructor(url: string | URL, protocols?: string | string[]) {
+  }
+}
+
+let originalWebSocket = WebSocket;
+
+before(() => {
+  originalWebSocket = WebSocket
+  // @ts-ignore
+  globalThis.WebSocket = FakeWebSocket
+})
+
+after(() => {
+  globalThis.WebSocket = originalWebSocket
+  originalWebSocket = null
+})
+
+
+describe('Websocket wrapped for scenes', () => {
+  const log = sinon.spy()
+  const logPreview = sinon.spy()
+  const wrappedProductionWebSocket = createWebSocket({
+    canUseWebsocket: true, log, previewMode: false
+  })
+  const wrappedPreviewWebSocket = createWebSocket({
+    canUseWebsocket: true, log: logPreview, previewMode: true
+  })
+  const wrappedNotAllowedWebSocket = createWebSocket({
+    canUseWebsocket: false, log, previewMode: false
+  })
+
+  it('should run successfully if the ws is secure in deployed scenes', async () => {
+    new wrappedProductionWebSocket("wss://decentraland.org")
+  })
+
+
+  it('should throw an error if the ws is not secure in deployed scenes', async () => {
+    const throwErrorLogger = sinon.spy()
+    try {
+      new wrappedProductionWebSocket("http://decentraland.org")
+    } catch (err) {
+      throwErrorLogger(err)
+    }
+    sinon.assert.calledOnce(throwErrorLogger)
+  })
+
+
+  it('should run successfully if the ws is secure in preview scenes', async () => {
+    new wrappedPreviewWebSocket("wss://decentraland.org")
+  })
+
+  it('should log an error if the ws is not secure in preview scenes', async () => {
+    sinon.assert.notCalled(logPreview)
+    new wrappedPreviewWebSocket("ws://decentraland.org")
+    sinon.assert.calledOnce(logPreview)
+  })
+
+  it('should throw an error because it does not have permissions', async () => {
+    const throwErrorLogger = sinon.spy()
+    try {
+      new wrappedNotAllowedWebSocket("wss://decentraland.org")
+    } catch (err) {
+      throwErrorLogger(err)
+    }
+    sinon.assert.calledOnce(throwErrorLogger)
+  })
+})


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Add a timeout opt for fetch requests
...

# Why? <!-- Explain the reason -->
We currently have one concurrent fetch per scene limitation, so when a request takes too long, then it blocks all the upcoming. Adding a { timeout: number } opt to the fetch so u can override the browser default timeout ( 300s ).

Also i changed the default timeout to 30000ms => 30s. (We can discuss about this number if u want)

```ts
fetch('https://some-url.casla', {}, { timeout: 100 }) 
...
