### PR TITLE
chore: fix exceptions in fetch and use single options object

### DIFF
--- a/packages/scene-system/sdk/Fetch.ts
+++ b/packages/scene-system/sdk/Fetch.ts
@@ -1,5 +1,7 @@
 import PQueue from 'p-queue/dist'
 
+const TIMEOUT_LIMIT = 29000
+
 export type FetchFunction = typeof fetch
 export interface FetchOptions {
   canUseFetch: boolean
@@ -9,31 +11,33 @@ export interface FetchOptions {
 }
 
 type Opts = {
-  timeout?: number
+  timeout: number
 }
 
 export function createFetch({ canUseFetch, previewMode, log, originalFetch }: FetchOptions) {
   const fifoFetch = new PQueue({ concurrency: 1 })
-  return (resource: RequestInfo, init?: RequestInit | undefined, opts?: Opts): Promise<Response> => {
+  return async (resource: RequestInfo, init?: (RequestInit & Partial<Opts>) | undefined): Promise<Response> => {
     const url = resource instanceof Request ? resource.url : resource
     if (url.toLowerCase().substr(0, 8) !== 'https://') {
       if (previewMode) {
-        log("Warning: Can't make an unsafe request in deployed scenes.")
+        log(
+          "⚠️ Warning: Can't make an unsafe http request in deployed scenes, please consider upgrading to https. url=" +
+            url
+        )
       } else {
-        throw new Error("Can't make an unsafe request")
+        return Promise.reject(new Error("Can't make an unsafe http request, please upgrade to https. url=" + url))
       }
     }
 
     if (!canUseFetch) {
-      throw new Error("This scene doesn't have allowed to use fetch")
+      return Promise.reject(new Error('This scene is not allowed to use fetch.'))
     }
 
     async function fetchRequest() {
       const abortController = new AbortController()
-      const TIMEOUT_LIMIT = 30000
       const timeout = setTimeout(() => {
         abortController.abort()
-      }, opts?.timeout || TIMEOUT_LIMIT)
+      }, init?.timeout || TIMEOUT_LIMIT)
       const response = await originalFetch(resource, { signal: abortController.signal, ...init })
       clearTimeout(timeout)
       return response

--- a/packages/scene-system/sdk/SceneRuntime.ts
+++ b/packages/scene-system/sdk/SceneRuntime.ts
@@ -106,8 +106,6 @@ export abstract class SceneRuntime extends Script {
 
   isPreview: boolean = false
 
-  private originalFetch!: typeof fetch
-
   private allowOpenExternalUrl: boolean = false
 
   constructor(transport: ScriptingTransport, opt?: ILogOpts) {
@@ -544,7 +542,7 @@ export abstract class SceneRuntime extends Script {
         const { EnvironmentAPI } = (await this.loadAPIs(['EnvironmentAPI'])) as { EnvironmentAPI: EnvironmentAPI }
         const unsafeAllowed = await EnvironmentAPI.areUnsafeRequestAllowed()
 
-        this.originalFetch = fetch
+        const originalFetch = fetch
 
         const restrictedWebSocket = createWebSocket({
           canUseWebsocket,
@@ -553,7 +551,7 @@ export abstract class SceneRuntime extends Script {
         })
         const restrictedFetch = createFetch({
           canUseFetch,
-          originalFetch: this.originalFetch,
+          originalFetch: originalFetch,
           previewMode: this.isPreview || unsafeAllowed,
           log: dcl.log
         })
@@ -561,7 +559,7 @@ export abstract class SceneRuntime extends Script {
         globalThis.fetch = restrictedFetch
         globalThis.WebSocket = restrictedWebSocket
 
-        await this.runCode(source as any as string, { dcl, WebSocket: restrictedWebSocket, fetch: restrictedFetch })
+        await this.runCode(source, { dcl, WebSocket: restrictedWebSocket, fetch: restrictedFetch })
 
         let modulesNotLoaded: string[] = []
 

--- a/packages/scene-system/sdk/WebSocket.ts
+++ b/packages/scene-system/sdk/WebSocket.ts
@@ -9,11 +9,14 @@ export function createWebSocket({ canUseWebsocket, previewMode, log }: WebSocket
     constructor(url: string | URL, protocols?: string | string[]) {
       if (url.toString().toLowerCase().substr(0, 4) !== 'wss:') {
         if (previewMode) {
-          log("Warning: can't connect to unsafe WebSocket server in deployed scenes.")
+          log(
+            "⚠️ Warning: can't connect to unsafe WebSocket (ws) server in deployed scenes, consider upgrading to wss."
+          )
         } else {
           throw new Error("Can't connect to unsafe WebSocket server")
         }
       }
+
       if (!canUseWebsocket) {
         throw new Error("This scene doesn't have allowed to use WebSocket")
       }

--- a/test/scene-system/sdk/fetchWrapper.spec.ts
+++ b/test/scene-system/sdk/fetchWrapper.spec.ts
@@ -101,7 +101,7 @@ describe('Fetch Wrapped for scenes' , () => {
     let error: Error = null
 
     try {
-      await wrappedDelayFetch('https://test.test/', {}, { timeout: 10 })
+      await wrappedDelayFetch('https://test.test/', { timeout: 10 })
     } catch (err) {
       console.log(err)
       error = err
@@ -113,7 +113,7 @@ describe('Fetch Wrapped for scenes' , () => {
     let error: Error = null
     let counter = 0
     await Promise.all([
-      wrappedDelayFetch('https://test.test/', {}, { timeout: 5 }).catch(err => {
+      wrappedDelayFetch('https://test.test/', { timeout: 5 }).catch(err => {
         error = err
         counter++
       }),


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Fix throw in synchronous execution and unifies RequestInit with Opts

# Why? <!-- Explain the reason -->
...

After merge, update kernel version in https://github.com/decentraland/js-sdk-toolchain/pull/121
