### PR TITLE
fix: removed friends initialization error notification

### DIFF
--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -91,12 +91,12 @@ function* initializeFriendsSaga() {
       yield call(waitForRendererInstance)
 
       getUnityInstance().ConfigureHUDElement(HUDElementID.FRIENDS, { active: false, visible: false })
-      getUnityInstance().ShowNotification({
-        type: NotificationType.GENERIC,
-        message: 'There was an error initializing friends and private messages',
-        buttonMessage: 'OK',
-        timer: 7
-      })
+      // getUnityInstance().ShowNotification({
+      //   type: NotificationType.GENERIC,
+      //   message: 'There was an error initializing friends and private messages',
+      //   buttonMessage: 'OK',
+      //   timer: 7
+      // })
     }
   }
 }


### PR DESCRIPTION
# What?
Removes friends initialization error notification

![Screenshot 2022-03-24 170506](https://user-images.githubusercontent.com/56365551/160000930-e6f3f7c4-a596-4f7a-97ae-345f2e0d5501.jpg)

# Why?
To improve user experience since its failing all the time
