### PR TITLE
add timeout opts to signed fetch

### DIFF
--- a/packages/atomicHelpers/flatFetch.ts
+++ b/packages/atomicHelpers/flatFetch.ts
@@ -1,3 +1,5 @@
+import { fetchWithTimeout, Opts } from 'scene-system/sdk/Fetch'
+
 export type FlatFetchResponse = {
   ok: boolean
   status: number
@@ -9,10 +11,10 @@ export type FlatFetchResponse = {
 
 export type BodyType = 'json' | 'text'
 
-export type FlatFetchInit = RequestInit & { responseBodyType?: BodyType }
+export type FlatFetchInit = RequestInit & { responseBodyType?: BodyType } & Opts
 
 export async function flatFetch(url: string, init?: FlatFetchInit): Promise<FlatFetchResponse> {
-  const response = await fetch(url, init)
+  const response = await fetchWithTimeout(fetch, url, init)
 
   const responseBodyType = init?.responseBodyType || 'text'
 

--- a/test/atomicHelpers/signedFetch.test.ts
+++ b/test/atomicHelpers/signedFetch.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai'
+
+import { sleep } from 'atomicHelpers/sleep'
+import { flatFetch } from 'atomicHelpers/flatFetch'
+
+describe('Signed Fetch' , () => {
+  window.fetch = async (resource: RequestInfo, init: RequestInit & { timeout: number }) => {
+    await sleep(100)
+    if (init.signal?.aborted) {
+      const a = new Error('Abort')
+      a.name = 'AbortError'
+      throw a
+    }
+    return new Response(JSON.stringify({ text: 'Done' }), init)
+  }
+  it('should abort fetch if reaches the timeout opt', async () => {
+    let error: Error = null
+
+    try {
+      await flatFetch('https://boedo.casla/', { timeout: 10 })
+    } catch (err) {
+      console.log(err)
+      error = err
+    }
+    expect(error.name).to.eql('AbortError')
+  })
+
+  it('should fetch and return a json response', async () => {
+    const { json } = await flatFetch('https://boedo.casla/', { timeout: 1000, responseBodyType: 'json' })
+    expect(json).to.eql({ text: 'Done' })
+  })
+
+  it('should fetch and return a text response ', async () => {
+    const { text } = await flatFetch('https://boedo.casla/', { timeout: 1000 })
+    expect(text).to.eql(JSON.stringify({ text: 'Done' }))
+  })
+})

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,6 +11,7 @@ import './atomicHelpers/landHelpers.test'
 import './atomicHelpers/vectorHelpers.test'
 import './atomicHelpers/OrderedRingBuffer.test'
 import './atomicHelpers/SortedLimitedQueue.test'
+import './atomicHelpers/signedFetch.test'
 
 /* UNIT */
 import './unit/ethereum.test'


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Add default timeout for singedFetch requests.
...

# Why? <!-- Explain the reason -->
We add this functionality to all the scene requests but forgot to add it to the signedFetch.
signedFetch use the same type as fetch so the timeout opt was already added but the implementation was missing 😢 
...
