### PR TITLE
feat: add third party ID to WearablesRequest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/redux-logger": "^3.0.9",
         "bignumber.js": "^9.0.1",
         "blob-to-buffer": "^1.2.8",
-        "dcl-catalyst-client": "^11.1.0",
+        "dcl-catalyst-client": "^11.2.0",
         "dcl-crypto": "^2.3.0",
         "dcl-quests-client": "^2.10.0",
         "dcl-scene-writer": "^1.1.2",
@@ -4439,17 +4439,40 @@
       "dev": true
     },
     "node_modules/dcl-catalyst-client": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-11.1.0.tgz",
-      "integrity": "sha512-I70e3I06V/3C+866cXkagS7oogPvwOhf+GEmu0A2VSqnlUKjz6GYE84PsYrMVzcvVhQNcTH5/qQWDmsyBa5JUw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-11.2.0.tgz",
+      "integrity": "sha512-D2W0Qcgpu9YrBPMtWYJPsOrAxYmkBLEGJADrNpNzhO4jxRxBYj2A6dKWatHcu28a/hrfqrt/pISjLJgzDPvy7Q==",
       "dependencies": {
         "@dcl/hashing": "^1.0.0",
-        "@dcl/schemas": "^3.8.0",
+        "@dcl/schemas": "^4.0.0",
         "@types/form-data": "^2.5.0",
         "cookie": "^0.4.1",
-        "dcl-catalyst-commons": "8.1.0",
+        "dcl-catalyst-commons": "8.1.2",
         "dcl-crypto": "^2.2.0",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/dcl-catalyst-client/node_modules/@dcl/schemas": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.2.0.tgz",
+      "integrity": "sha512-+YwEYRkUPtDuGhUFKSEKZxMe+ETqdIn0TBMyY8cJt+FijalXzOEFAPVj17TTCxz4V8SOW5qj2022N7FYzM/Qew==",
+      "dependencies": {
+        "ajv": "^7.1.0"
+      }
+    },
+    "node_modules/dcl-catalyst-client/node_modules/ajv": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+      "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/dcl-catalyst-client/node_modules/cookie": {
@@ -4460,13 +4483,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/dcl-catalyst-client/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/dcl-catalyst-commons": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-8.1.0.tgz",
-      "integrity": "sha512-cGwXfK2zdCKjWp6X63ropB4JxaKUv9xjPHIoOlNOMC89FBzQCAzC5ZQia+CvGuNDsVSHuRQribodpVF660RY5A==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-8.1.2.tgz",
+      "integrity": "sha512-MLgjSskdANljg3Ie68UYPmXdvEEziJPPmTlMv7mwoiYJ0D76H0ixCQOnCjw7/+uzl3rSm0p0ofjtHYufHoVlqw==",
       "dependencies": {
         "@dcl/hashing": "^1.0.0",
-        "@dcl/schemas": "3.8.0",
+        "@dcl/schemas": "4.1.0",
         "abort-controller": "^3.0.0",
         "cids": "^1.1.9",
         "cookie": "^0.4.1",
@@ -4480,6 +4508,29 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/dcl-catalyst-commons/node_modules/@dcl/schemas": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.1.0.tgz",
+      "integrity": "sha512-NCKWoK1KtrMlsP0hRM/4Btb4+o48gpi6ZCaEyDnDLYwuCJcApXISB3qaQY/FzdKuyfx6C3MEbjeCGZbhlEIhpQ==",
+      "dependencies": {
+        "ajv": "^7.1.0"
+      }
+    },
+    "node_modules/dcl-catalyst-commons/node_modules/ajv": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+      "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/dcl-catalyst-commons/node_modules/cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
@@ -4487,6 +4538,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/dcl-catalyst-commons/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/dcl-catalyst-commons/node_modules/node-fetch": {
       "version": "3.2.3",
@@ -6770,9 +6826,9 @@
       }
     },
     "node_modules/fetch-blob": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
-      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
       "funding": [
         {
           "type": "github",
@@ -18162,33 +18218,57 @@
       "dev": true
     },
     "dcl-catalyst-client": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-11.1.0.tgz",
-      "integrity": "sha512-I70e3I06V/3C+866cXkagS7oogPvwOhf+GEmu0A2VSqnlUKjz6GYE84PsYrMVzcvVhQNcTH5/qQWDmsyBa5JUw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-11.2.0.tgz",
+      "integrity": "sha512-D2W0Qcgpu9YrBPMtWYJPsOrAxYmkBLEGJADrNpNzhO4jxRxBYj2A6dKWatHcu28a/hrfqrt/pISjLJgzDPvy7Q==",
       "requires": {
         "@dcl/hashing": "^1.0.0",
-        "@dcl/schemas": "^3.8.0",
+        "@dcl/schemas": "^4.0.0",
         "@types/form-data": "^2.5.0",
         "cookie": "^0.4.1",
-        "dcl-catalyst-commons": "8.1.0",
+        "dcl-catalyst-commons": "8.1.2",
         "dcl-crypto": "^2.2.0",
         "form-data": "^4.0.0"
       },
       "dependencies": {
+        "@dcl/schemas": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.2.0.tgz",
+          "integrity": "sha512-+YwEYRkUPtDuGhUFKSEKZxMe+ETqdIn0TBMyY8cJt+FijalXzOEFAPVj17TTCxz4V8SOW5qj2022N7FYzM/Qew==",
+          "requires": {
+            "ajv": "^7.1.0"
+          }
+        },
+        "ajv": {
+          "version": "7.2.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+          "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "cookie": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
           "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },
     "dcl-catalyst-commons": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-8.1.0.tgz",
-      "integrity": "sha512-cGwXfK2zdCKjWp6X63ropB4JxaKUv9xjPHIoOlNOMC89FBzQCAzC5ZQia+CvGuNDsVSHuRQribodpVF660RY5A==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-8.1.2.tgz",
+      "integrity": "sha512-MLgjSskdANljg3Ie68UYPmXdvEEziJPPmTlMv7mwoiYJ0D76H0ixCQOnCjw7/+uzl3rSm0p0ofjtHYufHoVlqw==",
       "requires": {
         "@dcl/hashing": "^1.0.0",
-        "@dcl/schemas": "3.8.0",
+        "@dcl/schemas": "4.1.0",
         "abort-controller": "^3.0.0",
         "cids": "^1.1.9",
         "cookie": "^0.4.1",
@@ -18198,10 +18278,34 @@
         "node-fetch": "^3.0.0"
       },
       "dependencies": {
+        "@dcl/schemas": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.1.0.tgz",
+          "integrity": "sha512-NCKWoK1KtrMlsP0hRM/4Btb4+o48gpi6ZCaEyDnDLYwuCJcApXISB3qaQY/FzdKuyfx6C3MEbjeCGZbhlEIhpQ==",
+          "requires": {
+            "ajv": "^7.1.0"
+          }
+        },
+        "ajv": {
+          "version": "7.2.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+          "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "cookie": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
           "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node-fetch": {
           "version": "3.2.3",
@@ -20023,9 +20127,9 @@
       }
     },
     "fetch-blob": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
-      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/redux-logger": "^3.0.9",
     "bignumber.js": "^9.0.1",
     "blob-to-buffer": "^1.2.8",
-    "dcl-catalyst-client": "^11.1.0",
+    "dcl-catalyst-client": "^11.2.0",
     "dcl-crypto": "^2.3.0",
     "dcl-quests-client": "^2.10.0",
     "dcl-scene-writer": "^1.1.2",

--- a/packages/shared/catalogs/types.ts
+++ b/packages/shared/catalogs/types.ts
@@ -114,4 +114,5 @@ export type WearablesRequestFilters = {
   ownedByUser?: string
   wearableIds?: WearableId[]
   collectionIds?: string[]
+  thirdPartyId?: string
 }

--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -708,12 +708,14 @@ export class BrowserInterface {
       ownedByUser: string | null
       wearableIds?: string[] | null
       collectionIds?: string[] | null
+      thirdPartyId?: string | null
     }
     context?: string
   }) {
     const { filters, context } = data
     const newFilters: WearablesRequestFilters = {
       ownedByUser: filters.ownedByUser ?? undefined,
+      thirdPartyId: filters.thirdPartyId ?? undefined,
       wearableIds: arrayCleanup(filters.wearableIds),
       collectionIds: arrayCleanup(filters.collectionIds)
     }


### PR DESCRIPTION
# What?
Adds third party wearables support by extending `WearablesRequest` and using `catalyst-client:fetchOwnedThirdPartyWearables` method.

# Why?
In order to complete the feature in the Explorer ([PR](https://github.com/decentraland/unity-renderer/pull/1814)), this change is required to avoid explicit HTTP calls to the catalyst and keep using the same flow.

Resolves #257 