### PR TITLE
feat: remove entityId from AvatarReporter

### DIFF
--- a/packages/shared/social/avatarTracker.ts
+++ b/packages/shared/social/avatarTracker.ts
@@ -1,5 +1,5 @@
 import { getSceneWorkerBySceneID } from 'shared/world/parcelSceneManager'
-import { AvatarRendererMessage, AvatarRendererMessageType } from 'shared/types'
+import {AvatarRendererMessage, AvatarRendererMessageType} from 'shared/types'
 
 export function* getInSceneAvatarsUserId(sceneId: string): Iterable<string> {
   for (const [userId, avatarData] of rendererAvatars) {

--- a/packages/shared/social/avatarTracker.ts
+++ b/packages/shared/social/avatarTracker.ts
@@ -1,5 +1,5 @@
 import { getSceneWorkerBySceneID } from 'shared/world/parcelSceneManager'
-import {AvatarRendererMessage, AvatarRendererMessageType} from 'shared/types'
+import { AvatarRendererMessage, AvatarRendererMessageType } from 'shared/types'
 
 export function* getInSceneAvatarsUserId(sceneId: string): Iterable<string> {
   for (const [userId, avatarData] of rendererAvatars) {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -650,7 +650,6 @@ export enum AvatarRendererMessageType {
 }
 
 export type AvatarRendererBasePayload = {
-  entityId: string
   avatarShapeId: string
 }
 


### PR DESCRIPTION
# What? 

We are removing a property that is not used from the AvatarReporter

# Why? 

Since this property is not used we can safely remove it so the renderer can just delete that property safely. This way we don't need to create another message to support backward compatibility when there is no need for it
