### PR TITLE
fix: the parsing to disable and enable a feature from the url params

### DIFF
--- a/packages/shared/meta/selectors.ts
+++ b/packages/shared/meta/selectors.ts
@@ -79,13 +79,13 @@ export function getFeatureFlags(store: RootMetaState): FeatureFlag {
     }
   }
   if (location.search.length !== 0) {
-    const flags = location.search.substr(1, location.search.length - 1).split('&')
-    flags.forEach((element) => {
-      if (element.includes(`DISABLE_`)) {
-        const featureName = element.replace('DISABLE_', '').toLowerCase()
+    const flags = new URLSearchParams(location.search)
+    flags.forEach((_, key) => {
+      if (key.includes(`DISABLE_`)) {
+        const featureName = key.replace('DISABLE_', '').toLowerCase()
         featureFlag.flags[featureName] = false
-      } else if (location.search.includes(`ENABLE_`)) {
-        const featureName = element.replace('ENABLE_', '').toLowerCase()
+      } else if (key.includes(`ENABLE_`)) {
+        const featureName = key.replace('ENABLE_', '').toLowerCase()
         featureFlag.flags[featureName] = true
       }
     })

--- a/test/unit/meta.test.tsx
+++ b/test/unit/meta.test.tsx
@@ -1,0 +1,55 @@
+import { expect } from 'chai'
+import { buildStore } from '../../packages/shared/store/store'
+import { getFeatureFlags } from 'shared/meta/selectors'
+
+describe('Meta tests', () => {
+  describe('Parse feature flags', () => {
+
+    it('enable feature flags', () => {
+      const { store } = buildStore()
+      globalThis.globalStore = store
+
+      location.search = '&ENABLE_FEATURE1='
+
+      const features = getFeatureFlags(store.getState())
+
+      expect(features.flags['feature1']).to.equal(true)
+    })
+
+    it('disable feature flags', () => {
+      const { store } = buildStore()
+      globalThis.globalStore = store
+
+      location.search = '&DISABLE_FEATURE1='
+
+      const features = getFeatureFlags(store.getState())
+
+      expect(features.flags['feature1']).to.equal(false)
+    })
+
+    it('parse multiple feature flags', () => {
+      const { store } = buildStore()
+      globalThis.globalStore = store
+
+      location.search = '&DISABLE_ASSET_BUNDLES=&DISABLE_WEARABLES_ASSET_BUNDLES&ENABLE_FEATURE1=&ENABLE_FEATURE2'
+
+      const features = getFeatureFlags(store.getState())
+
+      expect(features.flags['asset_bundles']).to.equal(false)
+      expect(features.flags['wearables_asset_bundles']).to.equal(false)
+      expect(features.flags['feature1']).to.equal(true)
+      expect(features.flags['feature2']).to.equal(true)
+    })
+
+    it('override featureflag', () => {
+      const { store } = buildStore()
+      globalThis.globalStore = store
+
+      location.search = '&ENABLE_FEATURE1=&DISABLE_FEATURE1'
+
+      const features = getFeatureFlags(store.getState())
+
+      expect(features.flags['feature1']).to.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
# What? <!-- what is this PR? -->

Fix https://github.com/decentraland/unity-renderer/issues/2171

We're using from the Launcher the URLParams to create the URL to add parameters like:

```
DISABLE_ASSET_BUNDLES
DISABLE_WEARABLES_ASSET_BUNDLES
```

And the output URL using URLParams is:

```
&DISABLE_ASSET_BUNDLES=&DISABLE_WEARABLES_ASSET_BUNDLES=
```

This is totally valid based on http://www.faqs.org/rfcs/rfc2396.html (thanks @leanmendoza)

But the kernel is ignoring it due to incorrect parsing.