### PR TITLE
fix: Set the WORLD_CHAT_WINDOW visible param as FALSE by default

### DIFF
--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -51,7 +51,7 @@ function configureTaskbarDependentHUD(i: IUnityInterface, voiceChatEnabled: bool
       enableQuestPanel: isFeatureEnabled(store.getState(), FeatureFlags.QUESTS, false)
     }
   )
-  i.ConfigureHUDElement(HUDElementID.WORLD_CHAT_WINDOW, { active: true, visible: true })
+  i.ConfigureHUDElement(HUDElementID.WORLD_CHAT_WINDOW, { active: true, visible: false })
 
   i.ConfigureHUDElement(HUDElementID.CONTROLS_HUD, { active: true, visible: false })
   i.ConfigureHUDElement(HUDElementID.HELP_AND_SUPPORT_HUD, { active: true, visible: false })


### PR DESCRIPTION
# What? <!-- what is this PR? -->
We have changed the WORLD_CHAT_WINDOW `visible` param as `false` by default.

# Why? <!-- Explain the reason -->
When the application starts, kernel sends a message to Unity saying the chat should be visible by default, but the behaviour of the [**new redesign of the chat feature**](https://github.com/decentraland/unity-renderer/pull/1994) that we're currently implementing should be hidden by default and only be visible when the user clicks the chat icon or press enter.

# How to test it?
1. Go to https://play.decentraland.zone/?renderer-branch=feat/SocialBar&kernel-branch=fix/set-world-chat-window-visible-state-as-false-by-default
2. Check the new social window in the taskbar is initially closed.