### PR TITLE
fix: duplicated avatar for a same user

### DIFF
--- a/packages/ui/avatar/avatarSystem.ts
+++ b/packages/ui/avatar/avatarSystem.ts
@@ -132,7 +132,6 @@ export class AvatarEntity extends Entity {
   public remove() {
     if (this.isAddedToEngine()) {
       engine.removeEntity(this)
-      avatarMap.delete(this.userId)
     }
     // if (this.sub.isAddedToEngine()) engine.removeEntity(this.sub)
   }
@@ -195,6 +194,7 @@ function handleUserRemoved({ userId }: UserRemovedMessage): void {
     // setTimeout(() => {
     avatar.remove()
     // }, 2000)
+    avatarMap.delete(userId)
   }
 }
 


### PR DESCRIPTION
when avatar was set as not visible or removed and re-added to avoid renderer interpolation
it was also being removed from `avatarMap`
in a race condition `ensureAvatar` could create a new avatar entity even if an entity for that user already exists

for example
```
  setPose(pose: Pose): void {
    const [x, y, z, Qx, Qy, Qz, Qw, immediate] = pose

    const shouldReAddEntity = immediate && this.visible

    if (shouldReAddEntity) {
      this.remove()  //////////////////////////////----> avatar was being removed from engine and avatarMap
    }

    this.transform.position.set(x, y, z)
    this.transform.rotation.set(Qx, Qy, Qz, Qw)

    if (shouldReAddEntity) {
      engine.addEntity(this)  //////////////////////////////----> avatar was being re-added to the engine but not to avatarMap
    }
  }
```