### PR TITLE
fix: scene loading when wrong format for spawnpoints

### DIFF
--- a/packages/shared/world/positionThings.ts
+++ b/packages/shared/world/positionThings.ts
@@ -208,9 +208,13 @@ function computeComponentValue(x: number | number[]) {
     return x
   }
 
-  if (x.length !== 2) {
-    if (x.length < 2) x = [x[0], x[0]]
-    else x = [x[0], x[1]]
+  const length = x.length
+  if (length === 0) {
+    return 0
+  } else if (length < 2) {
+    return x[0]
+  } else if (length > 2) {
+    x = [x[0], x[1]]
   }
 
   let [min, max] = x

--- a/packages/shared/world/positionThings.ts
+++ b/packages/shared/world/positionThings.ts
@@ -209,7 +209,8 @@ function computeComponentValue(x: number | number[]) {
   }
 
   if (x.length !== 2) {
-    throw new Error(`array must have two values ${JSON.stringify(x)}`)
+    if (x.length < 2) x = [x[0], x[0]]
+    else x = [x[0], x[1]]
   }
 
   let [min, max] = x


### PR DESCRIPTION
Explorer never finish loading when teleporting to a scene with a wrong format for it spawnpoints.
We can see it happening here: https://play.decentraland.org/?position=-143,-125