### PR TITLE
feat: Make kernel capable of loading single items from the builder server

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -207,6 +207,7 @@ export function getTLD() {
   return 'org'
 }
 
+export const WITH_FIXED_ITEMS = (qs.get('WITH_ITEMS') && ensureSingleString(qs.get('WITH_ITEMS'))) || ''
 export const WITH_FIXED_COLLECTIONS =
   (qs.get('WITH_COLLECTIONS') && ensureSingleString(qs.get('WITH_COLLECTIONS'))) || ''
 export const ENABLE_EMPTY_SCENES = !location.search.includes('DISABLE_EMPTY_SCENES')

--- a/packages/shared/catalogs/sagas.ts
+++ b/packages/shared/catalogs/sagas.ts
@@ -8,7 +8,8 @@ import {
   DEBUG,
   ETHEREUM_NETWORK,
   BUILDER_SERVER_URL,
-  rootURLPreviewMode
+  rootURLPreviewMode,
+  WITH_FIXED_ITEMS
 } from 'config'
 
 import defaultLogger from 'shared/logger'
@@ -87,13 +88,25 @@ export function* handleWearablesRequest(action: WearablesRequest) {
 
 function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
   const catalystUrl: string = yield select(getCatalystServer)
+  const identity: ExplorerIdentity = yield select(getCurrentIdentity)
   const client: CatalystClient = new CatalystClient({ catalystUrl })
   const network: ETHEREUM_NETWORK = yield select(getSelectedNetwork)
-  const COLLECTIONS_ALLOWED = PREVIEW || ((DEBUG || getTLD() !== 'org') && network !== ETHEREUM_NETWORK.MAINNET)
+  const COLLECTIONS_OR_ITEMS_ALLOWED =
+    PREVIEW || ((DEBUG || getTLD() !== 'org') && network !== ETHEREUM_NETWORK.MAINNET)
 
   const result: PartialWearableV2[] = []
   if (filters.ownedByUser) {
-    if (WITH_FIXED_COLLECTIONS && COLLECTIONS_ALLOWED) {
+    if (WITH_FIXED_ITEMS && COLLECTIONS_OR_ITEMS_ALLOWED) {
+      const uuidsItems = WITH_FIXED_ITEMS.split(',')
+      if (uuidsItems.length > 0 && identity) {
+        const v2Wearables: PartialWearableV2[] = yield call(
+          fetchWearableByIdFromBuilder,
+          uuidsItems,
+          identity
+        )
+        result.push(...v2Wearables)
+      }
+    } else if (WITH_FIXED_COLLECTIONS && COLLECTIONS_OR_ITEMS_ALLOWED) {
       // The WITH_FIXED_COLLECTIONS config can only be used in zone. However, we want to be able to use prod collections for testing.
       // That's why we are also querying a prod catalyst for the given collections
       const collectionIds: string[] = WITH_FIXED_COLLECTIONS.split(',')
@@ -107,7 +120,6 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
 
       // Fetch unpublished collections from builder server
       const uuidCollections = collectionIds.filter((collectionId) => !collectionId.startsWith('urn'))
-      const identity: ExplorerIdentity = yield select(getCurrentIdentity)
       if (uuidCollections.length > 0 && identity) {
         const v2Wearables: PartialWearableV2[] = yield call(
           fetchWearablesByCollectionFromBuilder,
@@ -137,11 +149,20 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
     const wearables: PartialWearableV2[] = yield call(fetchWearablesByFilters, filters, client)
     result.push(...wearables)
 
-    if (WITH_FIXED_COLLECTIONS && COLLECTIONS_ALLOWED) {
+    if (WITH_FIXED_ITEMS && COLLECTIONS_OR_ITEMS_ALLOWED) {
+      const uuidsItems = WITH_FIXED_ITEMS.split(',')
+      if (uuidsItems.length > 0 && identity) {
+        const v2Wearables: PartialWearableV2[] = yield call(
+          fetchWearableByIdFromBuilder,
+          uuidsItems,
+          identity
+        )
+        result.push(...v2Wearables)
+      }
+    } else if (WITH_FIXED_COLLECTIONS && COLLECTIONS_OR_ITEMS_ALLOWED) {
       const uuidCollections = WITH_FIXED_COLLECTIONS.split(',').filter(
         (collectionId) => !collectionId.startsWith('urn')
       )
-      const identity: ExplorerIdentity = yield select(getCurrentIdentity)
       if (uuidCollections.length > 0 && identity) {
         const v2Wearables: PartialWearableV2[] = yield call(
           fetchWearablesByCollectionFromBuilder,
@@ -184,6 +205,29 @@ async function fetchWearablesByFilters(filters: WearablesRequestFilters, client:
   return client.fetchWearables(filters)
 }
 
+/**
+ * Fetches a single item from the Builder Server.
+ */
+async function fetchWearableByIdFromBuilder(uuidsItems: string[], identity: ExplorerIdentity): Promise<WearableV2[]> {
+  return Promise.all(
+    uuidsItems.map((uuid) => {
+      const path = `items/${uuid}`
+      const headers = BuilderServerAPIManager.authorize(identity, 'get', `/${path}`)
+      const itemResponse = (await fetchJson(
+        `${BUILDER_SERVER_URL}/${path}`,
+        {
+          headers
+        }
+      )) as { data: UnpublishedWearable; ok: boolean; error?: string }
+      if (!itemResponse.ok) {
+        throw new Error(itemResponse.error)
+      }
+    
+      return mapUnpublishedWearableIntoCatalystWearable(itemResponse.data) as WearableV2
+    }
+  )
+}
+
 async function fetchWearablesByCollectionFromBuilder(
   uuidCollections: string[],
   filters: WearablesRequestFilters | undefined,
@@ -208,6 +252,7 @@ async function fetchWearablesByCollectionFromBuilder(
   }
   return result
 }
+
 async function fetchWearablesByCollectionFromPreviewMode(filters: WearablesRequestFilters | undefined) {
   const result: WearableV2[] = []
   try {

--- a/packages/shared/catalogs/sagas.ts
+++ b/packages/shared/catalogs/sagas.ts
@@ -99,11 +99,7 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
     if (WITH_FIXED_ITEMS && COLLECTIONS_OR_ITEMS_ALLOWED) {
       const uuidsItems = WITH_FIXED_ITEMS.split(',')
       if (uuidsItems.length > 0 && identity) {
-        const v2Wearables: PartialWearableV2[] = yield call(
-          fetchWearableByIdFromBuilder,
-          uuidsItems,
-          identity
-        )
+        const v2Wearables: PartialWearableV2[] = yield call(fetchWearableByIdFromBuilder, uuidsItems, identity)
         result.push(...v2Wearables)
       }
     } else if (WITH_FIXED_COLLECTIONS && COLLECTIONS_OR_ITEMS_ALLOWED) {
@@ -152,11 +148,7 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
     if (WITH_FIXED_ITEMS && COLLECTIONS_OR_ITEMS_ALLOWED) {
       const uuidsItems = WITH_FIXED_ITEMS.split(',')
       if (uuidsItems.length > 0 && identity) {
-        const v2Wearables: PartialWearableV2[] = yield call(
-          fetchWearableByIdFromBuilder,
-          uuidsItems,
-          identity
-        )
+        const v2Wearables: PartialWearableV2[] = yield call(fetchWearableByIdFromBuilder, uuidsItems, identity)
         result.push(...v2Wearables)
       }
     } else if (WITH_FIXED_COLLECTIONS && COLLECTIONS_OR_ITEMS_ALLOWED) {
@@ -210,21 +202,18 @@ async function fetchWearablesByFilters(filters: WearablesRequestFilters, client:
  */
 async function fetchWearableByIdFromBuilder(uuidsItems: string[], identity: ExplorerIdentity): Promise<WearableV2[]> {
   return Promise.all(
-    uuidsItems.map((uuid) => {
+    uuidsItems.map(async (uuid) => {
       const path = `items/${uuid}`
       const headers = BuilderServerAPIManager.authorize(identity, 'get', `/${path}`)
-      const itemResponse = (await fetchJson(
-        `${BUILDER_SERVER_URL}/${path}`,
-        {
-          headers
-        }
-      )) as { data: UnpublishedWearable; ok: boolean; error?: string }
+      const itemResponse = (await fetchJson(`${BUILDER_SERVER_URL}/${path}`, {
+        headers
+      })) as { data: UnpublishedWearable; ok: boolean; error?: string }
       if (!itemResponse.ok) {
         throw new Error(itemResponse.error)
       }
-    
+
       return mapUnpublishedWearableIntoCatalystWearable(itemResponse.data) as WearableV2
-    }
+    })
   )
 }
 

--- a/packages/shared/catalogs/sagas.ts
+++ b/packages/shared/catalogs/sagas.ts
@@ -99,7 +99,7 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
     if (WITH_FIXED_ITEMS && COLLECTIONS_OR_ITEMS_ALLOWED) {
       const uuidsItems = WITH_FIXED_ITEMS.split(',')
       if (uuidsItems.length > 0 && identity) {
-        const v2Wearables: PartialWearableV2[] = yield call(fetchWearableByIdFromBuilder, uuidsItems, identity)
+        const v2Wearables: PartialWearableV2[] = yield call(fetchWearablesByIdFromBuilder, uuidsItems, identity)
         result.push(...v2Wearables)
       }
     } else if (WITH_FIXED_COLLECTIONS && COLLECTIONS_OR_ITEMS_ALLOWED) {
@@ -148,7 +148,7 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
     if (WITH_FIXED_ITEMS && COLLECTIONS_OR_ITEMS_ALLOWED) {
       const uuidsItems = WITH_FIXED_ITEMS.split(',')
       if (uuidsItems.length > 0 && identity) {
-        const v2Wearables: PartialWearableV2[] = yield call(fetchWearableByIdFromBuilder, uuidsItems, identity)
+        const v2Wearables: PartialWearableV2[] = yield call(fetchWearablesByIdFromBuilder, uuidsItems, identity)
         result.push(...v2Wearables)
       }
     } else if (WITH_FIXED_COLLECTIONS && COLLECTIONS_OR_ITEMS_ALLOWED) {
@@ -200,7 +200,7 @@ async function fetchWearablesByFilters(filters: WearablesRequestFilters, client:
 /**
  * Fetches a single item from the Builder Server.
  */
-async function fetchWearableByIdFromBuilder(uuidsItems: string[], identity: ExplorerIdentity): Promise<WearableV2[]> {
+async function fetchWearablesByIdFromBuilder(uuidsItems: string[], identity: ExplorerIdentity): Promise<WearableV2[]> {
   return Promise.all(
     uuidsItems.map(async (uuid) => {
       const path = `items/${uuid}`


### PR DESCRIPTION
# What? <!-- what is this PR? -->
This PR adds a method and a new query string to load a set of items from the builder server by id.

# Why? <!-- Explain the reason -->
We need a way to load sets of items into the world so curators and creators can view small sets of items. This feature is intended to be used with third party collection that contain thousands of items and can't be loaded as collections without pagination.
