### PR TITLE
chore: changing Synapse URL for Ropsten/dev

### DIFF
--- a/packages/shared/meta/sagas.ts
+++ b/packages/shared/meta/sagas.ts
@@ -129,7 +129,7 @@ async function fetchMetaConfiguration(network: ETHEREUM_NETWORK) {
       },
       bannedUsers: {},
       synapseUrl:
-        network === ETHEREUM_NETWORK.MAINNET ? 'https://synapse.decentraland.org' : 'https://synapse.decentraland.io',
+        network === ETHEREUM_NETWORK.MAINNET ? 'https://synapse.decentraland.org' : 'https://synapse.decentraland.zone',
       world: {
         pois: []
       },

--- a/packages/shared/meta/selectors.ts
+++ b/packages/shared/meta/selectors.ts
@@ -86,7 +86,7 @@ export function getFeatureFlags(store: RootMetaState): FeatureFlag {
 }
 
 export const getSynapseUrl = (store: RootMetaState): string =>
-  store.meta.config.synapseUrl ?? 'https://synapse.decentraland.io'
+  store.meta.config.synapseUrl ?? 'https://synapse.decentraland.zone'
 
 export const getCatalystNodesEndpoint = (store: RootMetaState): string | undefined =>
   store.meta.config.servers?.catalystsNodesEndpoint


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

This PR works along with [the global config PR](https://dcl.tools/ops/global-config/-/merge_requests/4/diffs).

# What? <!-- what is this PR? -->
Changes Ropsten/dev Synapse URL from `synapse.decentraland.io` to the new one `synapse.decentraland.zone`

# Why? <!-- Explain the reason -->
The domain was changed for this environment.
