### PR TITLE
fix: hot-reload in smart-wearables

### DIFF
--- a/packages/unity-interface/portableExperiencesUtils.ts
+++ b/packages/unity-interface/portableExperiencesUtils.ts
@@ -14,6 +14,7 @@ import { getUnityInstance } from './IUnityInterface'
 import { resolveUrlFromUrn } from '@dcl/urn-resolver'
 import { store } from 'shared/store/isolatedStore'
 import { addScenePortableExperience, removeScenePortableExperience } from 'shared/portableExperiences/actions'
+import { sleep } from 'atomicHelpers/sleep'
 
 declare let window: any
 
@@ -126,6 +127,10 @@ export async function declareWantedPortableExperiences(pxs: StorePortableExperie
       }
     }
   }
+
+  // TODO: this is an ugh workaround, fix controlling the scene lifecycle
+  // knowing when the scene was completly removed and then re-spawn it
+  await sleep(250)
 
   // then load all the missing scenes
   for (const sceneData of pxs) {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
This only brings back the `await sleep` set between the destruction and creation of Portable Experiences coded in:
https://github.com/decentraland/kernel/blob/039d162fdfd587106ab86c4018997cb2498d061f/packages/unity-interface/dcl.ts#L214


# Why? <!-- Explain the reason -->
The `spawnPx..` right now is ignored if it's called immediately after its destruction.

## NOTE: this is not a solution, just a workaround until the real problem be taken. 