### PR TITLE
fix: Allow URNs as item ids in the see in world feature

### DIFF
--- a/packages/shared/catalogs/sagas.ts
+++ b/packages/shared/catalogs/sagas.ts
@@ -97,10 +97,20 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
   const result: PartialWearableV2[] = []
   if (filters.ownedByUser) {
     if (WITH_FIXED_ITEMS && COLLECTIONS_OR_ITEMS_ALLOWED) {
-      const uuidsItems = WITH_FIXED_ITEMS.split(',')
-      if (uuidsItems.length > 0 && identity) {
-        const v2Wearables: PartialWearableV2[] = yield call(fetchWearablesByIdFromBuilder, uuidsItems, identity)
-        result.push(...v2Wearables)
+      const splittedItemIds = WITH_FIXED_ITEMS.split(',')
+      const itemUuids = splittedItemIds.filter((id) => !id.startsWith('urn'))
+      const itemURNs = splittedItemIds.filter((id) => id.startsWith('urn'))
+
+      if (identity) {
+        if (itemUuids.length > 0) {
+          const v2Wearables: PartialWearableV2[] = yield call(fetchWearablesByIdFromBuilder, itemUuids, identity)
+          result.push(...v2Wearables)
+        }
+
+        if (itemURNs.length > 0) {
+          const zoneWearables: PartialWearableV2[] = yield client.fetchWearables({ wearableIds: itemURNs })
+          result.push(...zoneWearables)
+        }
       }
     } else if (WITH_FIXED_COLLECTIONS && COLLECTIONS_OR_ITEMS_ALLOWED) {
       // The WITH_FIXED_COLLECTIONS config can only be used in zone. However, we want to be able to use prod collections for testing.
@@ -146,10 +156,20 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
     result.push(...wearables)
 
     if (WITH_FIXED_ITEMS && COLLECTIONS_OR_ITEMS_ALLOWED) {
-      const uuidsItems = WITH_FIXED_ITEMS.split(',')
-      if (uuidsItems.length > 0 && identity) {
-        const v2Wearables: PartialWearableV2[] = yield call(fetchWearablesByIdFromBuilder, uuidsItems, identity)
-        result.push(...v2Wearables)
+      const splittedItemIds = WITH_FIXED_ITEMS.split(',')
+      const itemUuids = splittedItemIds.filter((id) => !id.startsWith('urn'))
+      const itemURNs = splittedItemIds.filter((id) => id.startsWith('urn'))
+
+      if (identity) {
+        if (itemUuids.length > 0) {
+          const v2Wearables: PartialWearableV2[] = yield call(fetchWearablesByIdFromBuilder, itemUuids, identity)
+          result.push(...v2Wearables)
+        }
+
+        if (itemURNs.length > 0) {
+          const zoneWearables: PartialWearableV2[] = yield client.fetchWearables({ wearableIds: itemURNs })
+          result.push(...zoneWearables)
+        }
       }
     } else if (WITH_FIXED_COLLECTIONS && COLLECTIONS_OR_ITEMS_ALLOWED) {
       const uuidCollections = WITH_FIXED_COLLECTIONS.split(',').filter(

--- a/packages/shared/catalogs/sagas.ts
+++ b/packages/shared/catalogs/sagas.ts
@@ -1,4 +1,4 @@
-import { call, put, select, takeEvery } from 'redux-saga/effects'
+import { apply, call, put, select, takeEvery } from 'redux-saga/effects'
 
 import {
   WITH_FIXED_COLLECTIONS,
@@ -120,7 +120,9 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
       // Fetch published collections
       const urnCollections = collectionIds.filter((collectionId) => collectionId.startsWith('urn'))
       if (urnCollections.length > 0) {
-        const zoneWearables: PartialWearableV2[] = yield client.fetchWearables({ collectionIds: urnCollections })
+        const zoneWearables: PartialWearableV2[] = yield apply(client, client.fetchWearables, [
+          { collectionIds: urnCollections }
+        ])
         result.push(...zoneWearables)
       }
 
@@ -167,7 +169,9 @@ function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
         }
 
         if (itemURNs.length > 0) {
-          const zoneWearables: PartialWearableV2[] = yield client.fetchWearables({ wearableIds: itemURNs })
+          const zoneWearables: PartialWearableV2[] = yield apply(client, client.fetchWearables, [
+            { wearableIds: itemURNs }
+          ])
           result.push(...zoneWearables)
         }
       }


### PR DESCRIPTION
# What? <!-- what is this PR? -->
This PR implements a missing feature that allows the `WITH_ITEMS` property to support item URNs.

**Disclaimer**
A URL has a maximum length of 2048 characters, assuming URNs like `urn:decentraland:mumbai:collections-v2:0x3418e24d99b44e051932e40c98a461f2586be3d7:0` where its length is around 80 characters, only 25 URNs could be asked for and, taking into consideration that the URL usually has other query parameters defined, it will be able to query less than that. The catalyst client has a mechanism to split queries that have long query parameters so these 25 URNs won't break any requests to the Catalyst.

# Why? <!-- Explain the reason -->
We want to be able to load published items into the world.
