### PR TITLE
Revert "Remove chat and friends metrics (#296)"

### DIFF
--- a/packages/shared/analytics/hook-observable.ts
+++ b/packages/shared/analytics/hook-observable.ts
@@ -1,10 +1,28 @@
 import { Vector2 } from '@dcl/ecs-math'
 
 import { worldToGrid } from '../../atomicHelpers/parcelScenePositions'
+import { avatarMessageObservable } from '../comms/peers'
+import { AvatarMessageType } from '../comms/interface/types'
 import { positionObservable } from '../world/positionThings'
 import { trackEvent } from '.'
 
+const TRACEABLE_AVATAR_EVENTS = [
+  AvatarMessageType.USER_MUTED,
+  AvatarMessageType.USER_UNMUTED,
+  AvatarMessageType.USER_BLOCKED,
+  AvatarMessageType.USER_UNBLOCKED
+] as const
+
 export function hookAnalyticsObservables() {
+  avatarMessageObservable.add(({ type, ...data }) => {
+    const event = TRACEABLE_AVATAR_EVENTS.find((a) => a === type)
+    if (!event) {
+      return
+    }
+
+    trackEvent(event, data)
+  })
+
   let lastTime: number = performance.now()
 
   let previousPosition: string | null = null

--- a/packages/shared/analytics/hook-observable.ts
+++ b/packages/shared/analytics/hook-observable.ts
@@ -5,6 +5,7 @@ import { avatarMessageObservable } from '../comms/peers'
 import { AvatarMessageType } from '../comms/interface/types'
 import { positionObservable } from '../world/positionThings'
 import { trackEvent } from '.'
+import { TrackEvents } from './types'
 
 const TRACEABLE_AVATAR_EVENTS = [
   AvatarMessageType.USER_MUTED,
@@ -13,6 +14,10 @@ const TRACEABLE_AVATAR_EVENTS = [
   AvatarMessageType.USER_UNBLOCKED
 ] as const
 
+function toTrackingEvent<K extends keyof TrackEvents>(event: AvatarMessageType): K {
+  return ('Control ' + event.toString()) as K
+}
+
 export function hookAnalyticsObservables() {
   avatarMessageObservable.add(({ type, ...data }) => {
     const event = TRACEABLE_AVATAR_EVENTS.find((a) => a === type)
@@ -20,7 +25,9 @@ export function hookAnalyticsObservables() {
       return
     }
 
-    trackEvent(event, data)
+    const controlEvent = toTrackingEvent(event)
+
+    trackEvent(controlEvent, data)
   })
 
   let lastTime: number = performance.now()

--- a/packages/shared/analytics/types.ts
+++ b/packages/shared/analytics/types.ts
@@ -12,7 +12,6 @@ export type TrackEvents = PositionTrackEvents & {
   ['Control USER_UNMUTED']: { userId: string }
   ['Control USER_BLOCKED']: { userId: string }
   ['Control USER_UNBLOCKED']: { userId: string }
-  ['Control Chat message received']: { length: number; messageType: ChatMessageType }
   ['Control Send chat message']: { length: number; messageId: string; messageType: ChatMessageType }
   // TODO - the above metrics are reintroduced for control, remove asap - moliva - 2022/06/01
   ['Comms Status v2']: Record<string, any>

--- a/packages/shared/analytics/types.ts
+++ b/packages/shared/analytics/types.ts
@@ -1,11 +1,18 @@
 import { getPerformanceInfo } from '../session/getPerformanceInfo'
+import { ChatMessageType } from '../types'
 
 export type PositionTrackEvents = {
   ['Scene Spawn']: { parcel: string; spawnpoint: ReadOnlyVector3 }
 }
 
 export type TrackEvents = PositionTrackEvents & {
-  // Comms Events
+  // Comms & Chat Events
+  ['USER_MUTED']: { userId: string }
+  ['USER_UNMUTED']: { userId: string }
+  ['USER_BLOCKED']: { userId: string }
+  ['USER_UNBLOCKED']: { userId: string }
+  ['Chat message received']: { length: number; messageType: ChatMessageType }
+  ['Send chat message']: { length: number; messageId: string; messageType: ChatMessageType }
   ['Comms Status v2']: Record<string, any>
 
   // Info logs, such as networks or things we want to track
@@ -57,4 +64,10 @@ export type TrackEvents = PositionTrackEvents & {
   ['unity_initializing_end']: { renderer_version: string; loading_time: number }
   ['scene_start_event']: { scene_id: string; time_since_creation: number }
   ['invalid_schema']: { schema: string; payload: any }
+  ['Friend request approved']: Record<string, never> // {}
+  ['Friend request rejected']: Record<string, never> // {}
+  ['Friend request cancelled']: Record<string, never> // {}
+  ['Friend request received']: Record<string, never> // {}
+  ['Friend request sent']: Record<string, never> // {}
+  ['Friend deleted']: Record<string, never> // {}
 }

--- a/packages/shared/analytics/types.ts
+++ b/packages/shared/analytics/types.ts
@@ -7,12 +7,14 @@ export type PositionTrackEvents = {
 
 export type TrackEvents = PositionTrackEvents & {
   // Comms & Chat Events
-  ['USER_MUTED']: { userId: string }
-  ['USER_UNMUTED']: { userId: string }
-  ['USER_BLOCKED']: { userId: string }
-  ['USER_UNBLOCKED']: { userId: string }
-  ['Chat message received']: { length: number; messageType: ChatMessageType }
-  ['Send chat message']: { length: number; messageId: string; messageType: ChatMessageType }
+  // TODO - these are reintroduced for control, remove asap - moliva - 2022/06/01
+  ['Control USER_MUTED']: { userId: string }
+  ['Control USER_UNMUTED']: { userId: string }
+  ['Control USER_BLOCKED']: { userId: string }
+  ['Control USER_UNBLOCKED']: { userId: string }
+  ['Control Chat message received']: { length: number; messageType: ChatMessageType }
+  ['Control Send chat message']: { length: number; messageId: string; messageType: ChatMessageType }
+  // TODO - the above metrics are reintroduced for control, remove asap - moliva - 2022/06/01
   ['Comms Status v2']: Record<string, any>
 
   // Info logs, such as networks or things we want to track
@@ -64,10 +66,12 @@ export type TrackEvents = PositionTrackEvents & {
   ['unity_initializing_end']: { renderer_version: string; loading_time: number }
   ['scene_start_event']: { scene_id: string; time_since_creation: number }
   ['invalid_schema']: { schema: string; payload: any }
-  ['Friend request approved']: Record<string, never> // {}
-  ['Friend request rejected']: Record<string, never> // {}
-  ['Friend request cancelled']: Record<string, never> // {}
-  ['Friend request received']: Record<string, never> // {}
-  ['Friend request sent']: Record<string, never> // {}
-  ['Friend deleted']: Record<string, never> // {}
+  // TODO - these are reintroduced for control, remove asap - moliva - 2022/06/01
+  ['Control Friend request approved']: Record<string, never> // {}
+  ['Control Friend request rejected']: Record<string, never> // {}
+  ['Control Friend request cancelled']: Record<string, never> // {}
+  ['Control Friend request received']: Record<string, never> // {}
+  ['Control Friend request sent']: Record<string, never> // {}
+  ['Control Friend deleted']: Record<string, never> // {}
+  // TODO - the above metrics are reintroduced for control, remove asap - moliva - 2022/06/01
 }

--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -70,13 +70,6 @@ type MessageEvent = typeof MESSAGE_RECEIVED | typeof SEND_MESSAGE
 function* trackEvents(action: PayloadAction<MessageEvent, ChatMessage>) {
   const { type, payload } = action
   switch (type) {
-    case MESSAGE_RECEIVED: {
-      trackEvent('Control Chat message received', {
-        length: payload.body.length,
-        messageType: payload.messageType
-      })
-      break
-    }
     case SEND_MESSAGE: {
       trackEvent('Control Send chat message', {
         messageId: payload.messageId,

--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -71,14 +71,14 @@ function* trackEvents(action: PayloadAction<MessageEvent, ChatMessage>) {
   const { type, payload } = action
   switch (type) {
     case MESSAGE_RECEIVED: {
-      trackEvent('Chat message received', {
+      trackEvent('Control Chat message received', {
         length: payload.body.length,
         messageType: payload.messageType
       })
       break
     }
     case SEND_MESSAGE: {
-      trackEvent('Send chat message', {
+      trackEvent('Control Send chat message', {
         messageId: payload.messageId,
         length: payload.body.length,
         messageType: payload.messageType

--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -1,4 +1,5 @@
 import { takeEvery, put, select, call } from 'redux-saga/effects'
+import { PayloadAction } from 'typesafe-actions'
 import {
   MESSAGE_RECEIVED,
   MessageReceived,
@@ -10,6 +11,7 @@ import {
 import { uuid } from 'atomicHelpers/math'
 import { ChatMessageType, ChatMessage } from 'shared/types'
 import { EXPERIENCE_STARTED } from 'shared/loading/types'
+import { trackEvent } from 'shared/analytics'
 import { sendPublicChatMessage } from 'shared/comms'
 import { getAllPeers } from 'shared/comms/peers'
 import { parseParcelPosition, worldToGrid } from 'atomicHelpers/parcelScenePositions'
@@ -44,6 +46,8 @@ const fpsConfiguration = {
 export function* chatSaga(): any {
   initChatCommands()
 
+  yield takeEvery([MESSAGE_RECEIVED, SEND_MESSAGE], trackEvents)
+
   yield takeEvery(MESSAGE_RECEIVED, handleReceivedMessage)
   yield takeEvery(SEND_MESSAGE, handleSendMessage)
 
@@ -59,6 +63,29 @@ function* showWelcomeMessage() {
       body: 'Type /help for info about controls'
     })
   )
+}
+
+type MessageEvent = typeof MESSAGE_RECEIVED | typeof SEND_MESSAGE
+
+function* trackEvents(action: PayloadAction<MessageEvent, ChatMessage>) {
+  const { type, payload } = action
+  switch (type) {
+    case MESSAGE_RECEIVED: {
+      trackEvent('Chat message received', {
+        length: payload.body.length,
+        messageType: payload.messageType
+      })
+      break
+    }
+    case SEND_MESSAGE: {
+      trackEvent('Send chat message', {
+        messageId: payload.messageId,
+        length: payload.body.length,
+        messageType: payload.messageType
+      })
+      break
+    }
+  }
 }
 
 function* handleReceivedMessage(action: MessageReceived) {

--- a/packages/shared/comms/interface/types.ts
+++ b/packages/shared/comms/interface/types.ts
@@ -8,7 +8,14 @@ export const enum AvatarMessageType {
   USER_VISIBLE = 'USER_VISIBLE',
   USER_EXPRESSION = 'USER_EXPRESSION',
   USER_REMOVED = 'USER_REMOVED',
-  USER_TALKING = 'USER_TALKING'
+  USER_TALKING = 'USER_TALKING',
+
+  // TODO(mendez): what emits this messages?
+  // Actions related messages
+  USER_MUTED = 'USER_MUTED',
+  USER_UNMUTED = 'USER_UNMUTED',
+  USER_BLOCKED = 'USER_BLOCKED',
+  USER_UNBLOCKED = 'USER_UNBLOCKED'
 }
 
 export type ReceiveUserExpressionMessage = {
@@ -43,7 +50,12 @@ export type UserRemovedMessage = {
 }
 
 export type UserMessage = {
-  type: AvatarMessageType.USER_TALKING
+  type:
+    | AvatarMessageType.USER_BLOCKED
+    | AvatarMessageType.USER_UNBLOCKED
+    | AvatarMessageType.USER_MUTED
+    | AvatarMessageType.USER_UNMUTED
+    | AvatarMessageType.USER_TALKING
   userId: string
 }
 

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -638,27 +638,27 @@ function* trackEvents({ payload }: UpdateFriendship) {
   const { action } = payload
   switch (action) {
     case FriendshipAction.APPROVED: {
-      trackEvent('Friend request approved', {})
+      trackEvent('Control Friend request approved', {})
       break
     }
     case FriendshipAction.REJECTED: {
-      trackEvent('Friend request rejected', {})
+      trackEvent('Control Friend request rejected', {})
       break
     }
     case FriendshipAction.CANCELED: {
-      trackEvent('Friend request cancelled', {})
+      trackEvent('Control Friend request cancelled', {})
       break
     }
     case FriendshipAction.REQUESTED_FROM: {
-      trackEvent('Friend request received', {})
+      trackEvent('Control Friend request received', {})
       break
     }
     case FriendshipAction.REQUESTED_TO: {
-      trackEvent('Friend request sent', {})
+      trackEvent('Control Friend request sent', {})
       break
     }
     case FriendshipAction.DELETED: {
-      trackEvent('Friend deleted', {})
+      trackEvent('Control Friend deleted', {})
       break
     }
   }

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -81,6 +81,7 @@ export function* friendsSaga() {
   yield fork(initializeReceivedMessagesCleanUp)
 
   yield takeEvery(SET_MATRIX_CLIENT, configureMatrixClient)
+  yield takeEvery(UPDATE_FRIENDSHIP, trackEvents)
   yield takeEvery(UPDATE_FRIENDSHIP, handleUpdateFriendship)
   yield takeEvery(SEND_PRIVATE_MESSAGE, handleSendPrivateMessage)
 }
@@ -630,6 +631,36 @@ function* handleUpdateFriendship({ payload, meta }: UpdateFriendship) {
 
     // in case of any error, re initialize friends, to possibly correct state in both kernel and renderer
     yield call(refreshFriends)
+  }
+}
+
+function* trackEvents({ payload }: UpdateFriendship) {
+  const { action } = payload
+  switch (action) {
+    case FriendshipAction.APPROVED: {
+      trackEvent('Friend request approved', {})
+      break
+    }
+    case FriendshipAction.REJECTED: {
+      trackEvent('Friend request rejected', {})
+      break
+    }
+    case FriendshipAction.CANCELED: {
+      trackEvent('Friend request cancelled', {})
+      break
+    }
+    case FriendshipAction.REQUESTED_FROM: {
+      trackEvent('Friend request received', {})
+      break
+    }
+    case FriendshipAction.REQUESTED_TO: {
+      trackEvent('Friend request sent', {})
+      break
+    }
+    case FriendshipAction.DELETED: {
+      trackEvent('Friend deleted', {})
+      break
+    }
   }
 }
 


### PR DESCRIPTION
This reverts commit 96bd2273312aec679adab9838611725ceefe9cfe.

<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
We are reintroducing the chat metrics in kernel in order to have a control to compare with the new ones in renderer.

# Why? <!-- Explain the reason -->
...
