### PR TITLE
fix: null camera target set as undefined

### DIFF
--- a/.github/workflows/set-rollouts.yml
+++ b/.github/workflows/set-rollouts.yml
@@ -58,4 +58,4 @@ jobs:
           # Rollout information
           deploymentDomain: "play.decentraland.org"
           deploymentName: "@dcl/kernel"
-          percentage: 0
+          percentage: 100

--- a/packages/shared/apis/client/RestrictedActions.ts
+++ b/packages/shared/apis/client/RestrictedActions.ts
@@ -42,7 +42,7 @@ export function createRestrictedActionsServiceClient<Context>(clientPort: RpcCli
      * @param cameraTarget PositionType
      */
     async movePlayerTo(newPosition: PositionType, cameraTarget?: PositionType): Promise<void> {
-      await originalService.movePlayerTo({ newRelativePosition: newPosition, cameraTarget: cameraTarget })
+      await originalService.movePlayerTo({ newRelativePosition: newPosition, cameraTarget: cameraTarget || undefined })
     },
     /**
      * trigger an emote on the current player


### PR DESCRIPTION
Also set .org rollout to 100 (chore)

<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
...

# Why? <!-- Explain the reason -->
Fix the condition the cameraTarget is sent as null. Before the usage of @dcl/rpc this was working because the field wired as is and the remote procedure received the `null`, so the ifs were working fine. Now the field is serialized and the fields have to be able to be serialized, or if it's not going to wire, be undefined.
