### PR TITLE
fix: (rpc-web-transport) missed Uint8Array reference copying the received data.

### DIFF
--- a/packages/renderer-protocol/transports/webTransport.ts
+++ b/packages/renderer-protocol/transports/webTransport.ts
@@ -19,7 +19,8 @@ export function webTransport(options: WebTransportOptions): Transport {
   let isClosed = false
 
   ;(globalThis as any).DCL.BinaryMessageFromEngine = function (data: Uint8Array) {
-    events.emit('message', data)
+    const copiedData = new Uint8Array(data)
+    events.emit('message', copiedData)
   }
 
   const transport: Transport = {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Copy the received data and work with it.
Only it happens in chrome.

# Why? <!-- Explain the reason -->
While the promises are resolving, the Uint8Array reference linked to the WebAssembly heap is missed.
![image](https://user-images.githubusercontent.com/8042536/177621793-9c17793f-196a-4419-b994-cf0e21602e23.png)

