### PR TITLE
hotfix: POIs and map info not being reported to renderer

### DIFF
--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -185,7 +185,7 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
   const result: Array<LoadableScene> = yield call(fetchScenesByLocation, tiles)
 
   // filter non null & distinct
-  const sceneIds = Array.from(new Set<string>(result.map(($) => $.id)))
+  const sceneIds = Array.from(new Set<string>(result.filter(($) => !$.id.includes(',')).map(($) => $.id)))
 
   yield put(querySceneData(sceneIds))
 


### PR DESCRIPTION
Hotfix since POIs and Map information are not being reported to the renderer.
Reason: some ids here : https://github.com/decentraland/kernel/blob/main/packages/shared/atlas/sagas.ts#L188 are not OK (they have a `,` character) and it later fail fetching.

