### PR TITLE
feat: use new RPC URLs

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -234,8 +234,8 @@ function assertValue<T>(val: T | undefined | null): T {
 
 export namespace ethereumConfigurations {
   export const mainnet = {
-    wss: 'wss://mainnet.infura.io/ws/v3/f54f2e10b59647778de06d884121f8fa',
-    http: 'https://mainnet.infura.io/v3/f54f2e10b59647778de06d884121f8fa/',
+    wss: 'wss://rpc.decentraland.org/mainnet',
+    http: 'https://rpc.decentraland.org/mainnet',
     etherscan: 'https://etherscan.io',
     names: 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace',
 
@@ -246,8 +246,8 @@ export namespace ethereumConfigurations {
     MANAToken: assertValue(contractInfo.mainnet.MANAToken)
   }
   export const ropsten = {
-    wss: 'wss://ropsten.infura.io/ws/v3/f54f2e10b59647778de06d884121f8fa',
-    http: 'https://ropsten.infura.io/v3/f54f2e10b59647778de06d884121f8fa/',
+    wss: 'wss://rpc.decentraland.org/ropsten',
+    http: 'https://rpc.decentraland.org/ropsten',
     etherscan: 'https://ropsten.etherscan.io',
     names: 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace-ropsten',
 

--- a/static/export.html
+++ b/static/export.html
@@ -652,7 +652,7 @@
             kernel.authenticate(globalThis.ethereum, false)
           }
         } else {
-          kernel.authenticate('wss://mainnet.infura.io/ws/v3/f54f2e10b59647778de06d884121f8fa', true)
+          kernel.authenticate('wss://rpc.decentraland.org/mainnet', true)
         }
       }
 

--- a/static/index.html
+++ b/static/index.html
@@ -201,7 +201,7 @@
             kernel.authenticate(globalThis.ethereum, false)
           }
         } else {
-          kernel.authenticate('wss://mainnet.infura.io/ws/v3/f54f2e10b59647778de06d884121f8fa', true)
+          kernel.authenticate('wss://rpc.decentraland.org/mainnet', true)
         }
       }
 

--- a/static/preview.html
+++ b/static/preview.html
@@ -741,7 +741,7 @@
             kernel.authenticate(globalThis.ethereum, false)
           }
         } else {
-          kernel.authenticate('wss://mainnet.infura.io/ws/v3/f54f2e10b59647778de06d884121f8fa', true)
+          kernel.authenticate('wss://rpc.decentraland.org/mainnet', true)
         }
 
         if (isElectron()) {


### PR DESCRIPTION
# What? <!-- what is this PR? -->

It updates the infura URLs to use our new Cloudflare URLs that load balance nodes via rpc.decentraland.org
...

# Why? <!-- Explain the reason -->
...

We're trying to minimize the amount of infura keys we have and to centralize in a single URL requests to re-destribute them later