### PR TITLE
feat: prefer realm selection algorithm to get people together

### DIFF
--- a/packages/shared/dao/sagas.ts
+++ b/packages/shared/dao/sagas.ts
@@ -70,6 +70,8 @@ export function* daoSaga(): any {
 
 function* pickCatalystRealm() {
   const candidates: Candidate[] = yield select(getAllCatalystCandidates)
+  if (candidates.length === 0) return undefined
+
   let config: AlgorithmChainConfig | undefined = yield select(getPickRealmsAlgorithmConfig)
 
   if (!config || config.length === 0) {
@@ -165,10 +167,10 @@ function* selectRealm() {
     (PREVIEW ? PREVIEW_REALM : null) ||
     // CATALYST from url parameter
     (PIN_CATALYST ? realmFromPinnedCatalyst() : null) ||
-    // cached in local storage
-    (yield call(getRealmFromLocalStorage, network)) ||
     // fetch catalysts and select one using the load balancing
-    (yield call(pickCatalystRealm))
+    (yield call(pickCatalystRealm)) ||
+    // cached in local storage
+    (yield call(getRealmFromLocalStorage, network))
 
   if (!realm) debugger
 


### PR DESCRIPTION
If `localStorage` saved ream is chosen instead, there is no way to optimize realm selection to gather people together, instead a normal distribution across realms was achieved in the long run.