### PR TITLE
Feat: adds support to save and retrieve home point

### DIFF
--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -48,6 +48,7 @@ import { signalEngineReady } from 'shared/renderer/actions'
 import { IUnityInterface } from 'unity-interface/IUnityInterface'
 import { getCurrentUserProfile } from 'shared/profiles/selectors'
 import { sendHomeScene } from '../shared/atlas/actions'
+import { homePointKey } from '../shared/atlas/utils'
 
 const logger = createLogger('kernel: ')
 
@@ -265,7 +266,7 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
   })
 
   if (!HAS_INITIAL_POSITION_MARK) {
-    const homePoint: string = await getFromPersistentStorage('home-point')
+    const homePoint: string = await getFromPersistentStorage(homePointKey)
     if (homePoint) {
       store.dispatch(sendHomeScene(homePoint))
       const [x, y] = homePoint.split(',').map((p) => parseFloat(p))

--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -5,7 +5,7 @@ import { createLogger } from 'shared/logger'
 import { IDecentralandKernel, IEthereumProvider, KernelOptions, KernelResult, LoginState } from '@dcl/kernel-interface'
 import { BringDownClientAndShowError, ErrorContext, ReportFatalError } from 'shared/loading/ReportFatalError'
 import { renderingInBackground, renderingInForeground } from 'shared/loading/types'
-import { worldToGrid } from '../atomicHelpers/parcelScenePositions'
+import { gridToWorld, worldToGrid } from '../atomicHelpers/parcelScenePositions'
 import {
   DEBUG_WS_MESSAGES,
   ETHEREUM_NETWORK,
@@ -41,12 +41,13 @@ import { onLoginCompleted } from 'shared/session/sagas'
 import { authenticate, initSession } from 'shared/session/actions'
 import { localProfilesRepo } from 'shared/profiles/sagas'
 import { getStoredSession } from 'shared/session'
-import { setPersistentStorage } from 'atomicHelpers/persistentStorage'
+import { getFromPersistentStorage, setPersistentStorage } from 'atomicHelpers/persistentStorage'
 import { getCatalystServer, getFetchContentServer, getSelectedNetwork } from 'shared/dao/selectors'
 import { clientDebug } from 'unity-interface/ClientDebug'
 import { signalEngineReady } from 'shared/renderer/actions'
 import { IUnityInterface } from 'unity-interface/IUnityInterface'
 import { getCurrentUserProfile } from 'shared/profiles/selectors'
+import { sendHomeScene } from '../shared/atlas/actions'
 
 const logger = createLogger('kernel: ')
 
@@ -262,6 +263,15 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
     contentServerBundles: getAssetBundlesBaseUrl(getSelectedNetwork(state)) + '/',
     worldConfig: getWorldConfig(state)
   })
+
+  if (!HAS_INITIAL_POSITION_MARK) {
+    const homePoint: string = await getFromPersistentStorage('home-point')
+    if (homePoint) {
+      store.dispatch(sendHomeScene(homePoint))
+      const [x, y] = homePoint.split(',').map((p) => parseFloat(p))
+      gridToWorld(x, y, lastPlayerPosition)
+    }
+  }
 
   teleportObservable.notifyObservers(worldToGrid(lastPlayerPosition))
 

--- a/packages/shared/atlas/actions.ts
+++ b/packages/shared/atlas/actions.ts
@@ -29,6 +29,3 @@ export type SetHomeScene = ReturnType<typeof setHomeScene>
 export const SEND_HOME_SCENE_TO_UNITY = 'Send home scene to unity'
 export const sendHomeScene = (position: string) => action(SEND_HOME_SCENE_TO_UNITY, { position })
 export type SendHomeScene = ReturnType<typeof sendHomeScene>
-
-export const SEND_HOME_SCENE_COMPLETED = 'Send home scene to unity completed'
-export const sendHomeSceneCompleted = (position: string) => action(SEND_HOME_SCENE_COMPLETED, { position })

--- a/packages/shared/atlas/actions.ts
+++ b/packages/shared/atlas/actions.ts
@@ -23,5 +23,5 @@ export const initializePoiTiles = (tiles: string[]) => action(INITIALIZE_POI_TIL
 export type InitializePoiTiles = ReturnType<typeof initializePoiTiles>
 
 export const SET_HOME_SCENE = 'Set home scene'
-export const setHomeScene = (position: Vector2Component) => action(SET_HOME_SCENE, { position })
+export const setHomeScene = (position: string) => action(SET_HOME_SCENE, { position })
 export type SetHomeScene = ReturnType<typeof setHomeScene>

--- a/packages/shared/atlas/actions.ts
+++ b/packages/shared/atlas/actions.ts
@@ -30,5 +30,6 @@ export const SEND_HOME_SCENE_TO_UNITY = 'Send home scene to unity'
 export const sendHomeScene = (position: string) => action(SEND_HOME_SCENE_TO_UNITY, { position })
 export type SendHomeScene = ReturnType<typeof sendHomeScene>
 
+export const SEND_HOME_SCENE_COMPLETED = 'Send home scene to unity completed'
 export const sendHomeSceneCompleted = (position: string) =>
   action(SEND_HOME_SCENE_COMPLETED, { position })

--- a/packages/shared/atlas/actions.ts
+++ b/packages/shared/atlas/actions.ts
@@ -23,5 +23,5 @@ export const initializePoiTiles = (tiles: string[]) => action(INITIALIZE_POI_TIL
 export type InitializePoiTiles = ReturnType<typeof initializePoiTiles>
 
 export const SET_HOME_SCENE = 'Set home scene'
-export const setHomeScene = (position: Vector2Component) => action(SET_HOME_SCENE, {position})
+export const setHomeScene = (position: Vector2Component) => action(SET_HOME_SCENE, { position })
 export type SetHomeScene = ReturnType<typeof setHomeScene>

--- a/packages/shared/atlas/actions.ts
+++ b/packages/shared/atlas/actions.ts
@@ -31,5 +31,4 @@ export const sendHomeScene = (position: string) => action(SEND_HOME_SCENE_TO_UNI
 export type SendHomeScene = ReturnType<typeof sendHomeScene>
 
 export const SEND_HOME_SCENE_COMPLETED = 'Send home scene to unity completed'
-export const sendHomeSceneCompleted = (position: string) =>
-  action(SEND_HOME_SCENE_COMPLETED, { position })
+export const sendHomeSceneCompleted = (position: string) => action(SEND_HOME_SCENE_COMPLETED, { position })

--- a/packages/shared/atlas/actions.ts
+++ b/packages/shared/atlas/actions.ts
@@ -27,5 +27,5 @@ export const setHomeScene = (position: string) => action(SET_HOME_SCENE, { posit
 export type SetHomeScene = ReturnType<typeof setHomeScene>
 
 export const SEND_HOME_SCENE_TO_UNITY = 'Send home scene to unity'
-export const sendHomeScene = (position: string) => action (SEND_HOME_SCENE_TO_UNITY, { position })
+export const sendHomeScene = (position: string) => action(SEND_HOME_SCENE_TO_UNITY, { position })
 export type SendHomeScene = ReturnType<typeof sendHomeScene>

--- a/packages/shared/atlas/actions.ts
+++ b/packages/shared/atlas/actions.ts
@@ -21,3 +21,7 @@ export type ReportLastPosition = ReturnType<typeof reportLastPosition>
 export const INITIALIZE_POI_TILES = 'Initialize POI tiles'
 export const initializePoiTiles = (tiles: string[]) => action(INITIALIZE_POI_TILES, { tiles })
 export type InitializePoiTiles = ReturnType<typeof initializePoiTiles>
+
+export const SET_HOME_SCENE = 'Set home scene'
+export const setHomeScene = (position: Vector2Component) => action(SET_HOME_SCENE, {position})
+export type SetHomeScene = ReturnType<typeof setHomeScene>

--- a/packages/shared/atlas/actions.ts
+++ b/packages/shared/atlas/actions.ts
@@ -25,3 +25,7 @@ export type InitializePoiTiles = ReturnType<typeof initializePoiTiles>
 export const SET_HOME_SCENE = 'Set home scene'
 export const setHomeScene = (position: string) => action(SET_HOME_SCENE, { position })
 export type SetHomeScene = ReturnType<typeof setHomeScene>
+
+export const SEND_HOME_SCENE_TO_UNITY = 'Send home scene to unity'
+export const sendHomeScene = (position: string) => action (SEND_HOME_SCENE_TO_UNITY, { position })
+export type SendHomeScene = ReturnType<typeof sendHomeScene>

--- a/packages/shared/atlas/actions.ts
+++ b/packages/shared/atlas/actions.ts
@@ -29,3 +29,6 @@ export type SetHomeScene = ReturnType<typeof setHomeScene>
 export const SEND_HOME_SCENE_TO_UNITY = 'Send home scene to unity'
 export const sendHomeScene = (position: string) => action(SEND_HOME_SCENE_TO_UNITY, { position })
 export type SendHomeScene = ReturnType<typeof sendHomeScene>
+
+export const sendHomeSceneCompleted = (position: string) =>
+  action(SEND_HOME_SCENE_COMPLETED, { position })

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -42,7 +42,7 @@ import { waitForRendererInstance } from 'shared/renderer/sagas-helper'
 import { waitForRealmInitialized } from 'shared/dao/sagas'
 import { Scene } from '@dcl/schemas'
 import { saveToPersistentStorage } from 'atomicHelpers/persistentStorage'
-import { homePointKey } from './utils'
+import { homePointKey } from 'shared/atlas/utils'
 
 export function* atlasSaga(): any {
   yield takeEvery(SCENE_LOAD, checkAndReportAround)

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -112,7 +112,6 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
 function* setHomeSceneAction(action: SetHomeScene) {
   defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
   yield call(setHomeScene(action.payload.position))
-  getUnityInstance().UpdateHomeScene(action.payload.position)
 }
 
 function* reportScenes(scenes: LoadableScene[]): any {

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -111,7 +111,8 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
 
 function* setHomeSceneAction(action: SetHomeScene) {
   defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
-  yield put(setHomeScene(action.payload.position))
+  yield call(setHomeScene(action.payload.position))
+  getUnityInstance().UpdateHomeScene(action.payload.position);
 }
 
 function* reportScenes(scenes: LoadableScene[]): any {

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -48,7 +48,7 @@ export function* atlasSaga(): any {
 
   yield takeLatest(REPORT_SCENES_AROUND_PARCEL, reportScenesAroundParcelAction)
   yield takeEvery(REPORT_SCENES_FROM_TILES, reportScenesFromTilesAction)
-  yield takeEvery(SET_HOME_SCENE, setHomeScene)
+  yield takeEvery(SET_HOME_SCENE, setHomeSceneAction)
 }
 
 const TRIGGER_DISTANCE = 10 * parcelLimits.parcelSize
@@ -109,7 +109,7 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
   yield put(reportedScenes(tiles))
 }
 
-function* setHomeScene(position: SetHomeScene) {
+function* setHomeSceneAction(position: SetHomeScene) {
   defaultLogger.warn(`Setting home scene to ${position}`)
 }
 

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -23,7 +23,10 @@ import {
   REPORT_SCENES_FROM_TILES,
   SetHomeScene,
   SET_HOME_SCENE,
-  sendHomeScene
+  SendHomeScene,
+  sendHomeScene,
+  SEND_HOME_SCENE_TO_UNITY,
+  sendHomeSceneCompleted
 } from './actions'
 import { getPoiTiles, postProcessSceneName } from './selectors'
 import { RootAtlasState } from './types'
@@ -49,6 +52,7 @@ export function* atlasSaga(): any {
   yield takeLatest(REPORT_SCENES_AROUND_PARCEL, reportScenesAroundParcelAction)
   yield takeEvery(REPORT_SCENES_FROM_TILES, reportScenesFromTilesAction)
   yield takeEvery(SET_HOME_SCENE, setHomeSceneAction)
+  yield takeEvery(SEND_HOME_SCENE_TO_UNITY, sendHomeSceneToUnityAction)
 }
 
 const TRIGGER_DISTANCE = 10 * parcelLimits.parcelSize
@@ -112,6 +116,11 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
 function* setHomeSceneAction(action: SetHomeScene) {
   defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
   yield put(sendHomeScene(action.payload.position))
+}
+
+function* sendHomeSceneToUnityAction(action: SendHomeScene) {
+  defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
+  yield put(sendHomeSceneCompleted(action.payload.position))
 }
 
 function* reportScenes(scenes: LoadableScene[]): any {

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -41,6 +41,7 @@ import { getUnityInstance } from 'unity-interface/IUnityInterface'
 import { waitForRendererInstance } from 'shared/renderer/sagas-helper'
 import { waitForRealmInitialized } from 'shared/dao/sagas'
 import { Scene } from '@dcl/schemas'
+import { saveToPersistentStorage } from 'atomicHelpers/persistentStorage'
 
 export function* atlasSaga(): any {
   yield takeEvery(SCENE_LOAD, checkAndReportAround)
@@ -114,6 +115,7 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
 
 function* setHomeSceneAction(action: SetHomeScene) {
   defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
+  yield call(saveToPersistentStorage, 'homePoint', action.payload.position)
   yield put(sendHomeScene(action.payload.position))
 }
 

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -121,6 +121,8 @@ function* setHomeSceneAction(action: SetHomeScene) {
 function* sendHomeSceneToUnityAction(action: SendHomeScene) {
   defaultLogger.warn(`Send home scene ${action.payload.position}`)
   yield put(sendHomeSceneCompleted(action.payload.position))
+  yield call(waitForRendererInstance)
+  getUnityInstance().UpdateHomeScene(action.payload.position)
 }
 
 function* reportScenes(scenes: LoadableScene[]): any {

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -42,7 +42,7 @@ import { waitForRendererInstance } from 'shared/renderer/sagas-helper'
 import { waitForRealmInitialized } from 'shared/dao/sagas'
 import { Scene } from '@dcl/schemas'
 import { saveToPersistentStorage } from 'atomicHelpers/persistentStorage'
-import { homePointKey } from 'shared/atlas/utils'
+import { homePointKey } from './utils'
 
 export function* atlasSaga(): any {
   yield takeEvery(SCENE_LOAD, checkAndReportAround)

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -23,7 +23,8 @@ import {
   REPORT_SCENES_FROM_TILES,
   SetHomeScene,
   setHomeScene,
-  SET_HOME_SCENE
+  SET_HOME_SCENE,
+  sendHomeScene
 } from './actions'
 import { getPoiTiles, postProcessSceneName } from './selectors'
 import { RootAtlasState } from './types'
@@ -111,7 +112,7 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
 
 function* setHomeSceneAction(action: SetHomeScene) {
   defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
-  yield call(setHomeScene(action.payload.position))
+  yield put(sendHomeScene(action.payload.position))
 }
 
 function* reportScenes(scenes: LoadableScene[]): any {

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -119,7 +119,7 @@ function* setHomeSceneAction(action: SetHomeScene) {
 }
 
 function* sendHomeSceneToUnityAction(action: SendHomeScene) {
-  defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
+  defaultLogger.warn(`Send home scene ${action.payload.position}`)
   yield put(sendHomeSceneCompleted(action.payload.position))
 }
 

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -109,8 +109,9 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
   yield put(reportedScenes(tiles))
 }
 
-function* setHomeSceneAction(position: SetHomeScene) {
-  defaultLogger.warn(`Setting home scene to ${position}`)
+function* setHomeSceneAction(action: SetHomeScene) {
+  defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
+  yield put(setHomeScene(action.payload.position))
 }
 
 function* reportScenes(scenes: LoadableScene[]): any {

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -109,7 +109,7 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
   yield put(reportedScenes(tiles))
 }
 
-function* setHomeScene(position: Vector2Component) {
+function* setHomeScene(position: SetHomeScene) {
   defaultLogger.warn(`Setting home scene to ${position}`)
 }
 

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -112,7 +112,7 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
 function* setHomeSceneAction(action: SetHomeScene) {
   defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
   yield call(setHomeScene(action.payload.position))
-  getUnityInstance().UpdateHomeScene(action.payload.position);
+  getUnityInstance().UpdateHomeScene(action.payload.position)
 }
 
 function* reportScenes(scenes: LoadableScene[]): any {

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -22,7 +22,6 @@ import {
   reportScenesFromTiles,
   REPORT_SCENES_FROM_TILES,
   SetHomeScene,
-  setHomeScene,
   SET_HOME_SCENE,
   sendHomeScene
 } from './actions'

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -115,14 +115,11 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
 }
 
 function* setHomeSceneAction(action: SetHomeScene) {
-  defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
   yield call(saveToPersistentStorage, homePointKey, action.payload.position)
   yield put(sendHomeScene(action.payload.position))
 }
 
 function* sendHomeSceneToUnityAction(action: SendHomeScene) {
-  defaultLogger.warn(`Send home scene ${action.payload.position}`)
-
   yield call(waitForRendererInstance)
   getUnityInstance().UpdateHomeScene(action.payload.position)
 }

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -20,7 +20,10 @@ import {
   INITIALIZE_POI_TILES,
   ReportScenesFromTile,
   reportScenesFromTiles,
-  REPORT_SCENES_FROM_TILES
+  REPORT_SCENES_FROM_TILES,
+  SetHomeScene,
+  setHomeScene,
+  SET_HOME_SCENE
 } from './actions'
 import { getPoiTiles, postProcessSceneName } from './selectors'
 import { RootAtlasState } from './types'
@@ -45,6 +48,7 @@ export function* atlasSaga(): any {
 
   yield takeLatest(REPORT_SCENES_AROUND_PARCEL, reportScenesAroundParcelAction)
   yield takeEvery(REPORT_SCENES_FROM_TILES, reportScenesFromTilesAction)
+  yield takeEvery(SET_HOME_SCENE, setHomeScene)
 }
 
 const TRIGGER_DISTANCE = 10 * parcelLimits.parcelSize
@@ -103,6 +107,10 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
 
   yield call(reportScenes, result)
   yield put(reportedScenes(tiles))
+}
+
+function* setHomeScene(position: Vector2Component) {
+  defaultLogger.warn(`Setting home scene to ${position}`)
 }
 
 function* reportScenes(scenes: LoadableScene[]): any {

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -42,6 +42,7 @@ import { waitForRendererInstance } from 'shared/renderer/sagas-helper'
 import { waitForRealmInitialized } from 'shared/dao/sagas'
 import { Scene } from '@dcl/schemas'
 import { saveToPersistentStorage } from 'atomicHelpers/persistentStorage'
+import { homePointKey } from './utils'
 
 export function* atlasSaga(): any {
   yield takeEvery(SCENE_LOAD, checkAndReportAround)
@@ -115,7 +116,7 @@ function* reportScenesFromTilesAction(action: ReportScenesFromTile) {
 
 function* setHomeSceneAction(action: SetHomeScene) {
   defaultLogger.warn(`Setting home scene to ${action.payload.position}`)
-  yield call(saveToPersistentStorage, 'homePoint', action.payload.position)
+  yield call(saveToPersistentStorage, homePointKey, action.payload.position)
   yield put(sendHomeScene(action.payload.position))
 }
 

--- a/packages/shared/atlas/sagas.ts
+++ b/packages/shared/atlas/sagas.ts
@@ -25,8 +25,7 @@ import {
   SET_HOME_SCENE,
   SendHomeScene,
   sendHomeScene,
-  SEND_HOME_SCENE_TO_UNITY,
-  sendHomeSceneCompleted
+  SEND_HOME_SCENE_TO_UNITY
 } from './actions'
 import { getPoiTiles, postProcessSceneName } from './selectors'
 import { RootAtlasState } from './types'
@@ -120,7 +119,7 @@ function* setHomeSceneAction(action: SetHomeScene) {
 
 function* sendHomeSceneToUnityAction(action: SendHomeScene) {
   defaultLogger.warn(`Send home scene ${action.payload.position}`)
-  yield put(sendHomeSceneCompleted(action.payload.position))
+
   yield call(waitForRendererInstance)
   getUnityInstance().UpdateHomeScene(action.payload.position)
 }

--- a/packages/shared/atlas/utils.ts
+++ b/packages/shared/atlas/utils.ts
@@ -1,1 +1,0 @@
-export const homePointKey = "homePointKey"

--- a/packages/shared/atlas/utils.ts
+++ b/packages/shared/atlas/utils.ts
@@ -1,1 +1,1 @@
-export const homePointKey = "homePointKey"
+export const homePointKey = 'home-point'

--- a/packages/shared/atlas/utils.ts
+++ b/packages/shared/atlas/utils.ts
@@ -1,0 +1,1 @@
+export const homePointKey = "homePointKey"

--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -482,6 +482,10 @@ export class BrowserInterface {
     })
   }
 
+  public SetHomeScene(data: {sceneId: string }) {
+    
+  }
+
   public ReportPlayer(data: { userId: string }) {
     this.OpenWebURL({
       url: `https://dcl.gg/report-user-or-scene?scene_or_name=${data.userId}`

--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -4,7 +4,7 @@ import { uuid } from 'atomicHelpers/math'
 import { sendPublicChatMessage } from 'shared/comms'
 import { findProfileByName } from 'shared/profiles/selectors'
 import { TeleportController } from 'shared/world/TeleportController'
-import { reportScenesAroundParcel } from 'shared/atlas/actions'
+import { reportScenesAroundParcel, setHomeScene } from 'shared/atlas/actions'
 import { getCurrentIdentity, getCurrentUserId, getIsGuestLogin } from 'shared/session/selectors'
 import { DEBUG, ethereumConfigurations, parcelLimits, playerConfigurations, WORLD_EXPLORER } from 'config'
 import { trackEvent } from 'shared/analytics'
@@ -482,8 +482,8 @@ export class BrowserInterface {
     })
   }
 
-  public SetHomeScene(data: {sceneId: string }) {
-    
+  public SetHomeScene(data: { sceneId: string }) {
+    store.dispatch(setHomeScene([data.sceneId]))
   }
 
   public ReportPlayer(data: { userId: string }) {

--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -483,7 +483,7 @@ export class BrowserInterface {
   }
 
   public SetHomeScene(data: { sceneId: string }) {
-    store.dispatch(setHomeScene([data.sceneId]))
+    store.dispatch(setHomeScene(data.sceneId))
   }
 
   public ReportPlayer(data: { userId: string }) {

--- a/packages/unity-interface/IUnityInterface.ts
+++ b/packages/unity-interface/IUnityInterface.ts
@@ -70,6 +70,7 @@ export interface IUnityInterface {
   SendGenericMessage(object: string, method: string, payload: string): void
   SetDebug(): void
   LoadProfile(profile: NewProfileForRenderer): void
+  UpdateHomeScene(sceneId: string): void
   SetRenderProfile(id: RenderProfile): void
   CreateGlobalScene(data: {
     id: string

--- a/packages/unity-interface/UnityInterface.ts
+++ b/packages/unity-interface/UnityInterface.ts
@@ -117,6 +117,10 @@ export class UnityInterface implements IUnityInterface {
     this.SendMessageToUnity('Main', 'LoadProfile', JSON.stringify(profile))
   }
 
+  public UpdateHomeScene(sceneId: string) {
+    this.SendMessageToUnity('Main', 'UpdateHomeScene', sceneId)
+  }
+
   public SetRenderProfile(id: RenderProfile) {
     this.SendMessageToUnity('Main', 'SetRenderProfile', JSON.stringify({ id: id }))
   }


### PR DESCRIPTION
Closes #444 

Adds the required function to save and retrieve the home point coordinates,  also spawns the player in the home point position unless overwritten in the url with the "position" query parameter.

To be tested with the following unity-renderer branch: 