### PR TITLE
feat: Remove version field from the profile's avatar object

### DIFF
--- a/packages/shared/profiles/transformations/profileToRendererFormat.ts
+++ b/packages/shared/profiles/transformations/profileToRendererFormat.ts
@@ -39,7 +39,6 @@ export function profileToRendererFormat(
     avatar: {
       wearables: profile.avatar?.wearables || [],
       emotes: profile.avatar?.emotes || [],
-      version: profile.avatar?.emotes !== undefined ? 1 : 0,
       bodyShape: profile.avatar?.bodyShape || '',
       eyeColor: convertToRGBObject(profile.avatar?.eyes.color),
       hairColor: convertToRGBObject(profile.avatar?.hair.color),

--- a/packages/shared/profiles/transformations/types.ts
+++ b/packages/shared/profiles/transformations/types.ts
@@ -19,7 +19,6 @@ export type NewProfileForRenderer = {
       slot: number
       urn: string
     }[]
-    version: number // @TODO: remove this once Emotes is fully released. This helps the Renderer to know if it should fetch Emotes separately.
   }
 
   // TODO evaluate usage of the following


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Since the Renderer won't need this field anymore, this PR removes it from the `avatar` object. This is a follow-up PR to: https://github.com/decentraland/kernel/pull/486.

# Why? <!-- Explain the reason -->
It was passed to the Renderer so it knows when to send emotes separately or not but since it will always send them as `emotes`, it's not needed.
