### PR TITLE
fix: emotes ADR74

### DIFF
--- a/packages/ui/avatar/avatarSystem.ts
+++ b/packages/ui/avatar/avatarSystem.ts
@@ -71,13 +71,7 @@ export class AvatarEntity extends Entity {
 
       shape.bodyShape = avatar.bodyShape
       shape.wearables = avatar.wearables
-
-      // Hack to enable emotes with the new profile format
-      // this should be deleted once this PR is merged and implemented in renderer
-      // https://github.com/decentraland/protocol/pull/39
-      if (profile.avatar.emotes) {
-        shape.wearables.push(...profile.avatar.emotes.map(($) => $.urn))
-      }
+      shape.emotes = avatar.emotes
 
       shape.skinColor = avatar.skinColor
       shape.hairColor = avatar.hairColor


### PR DESCRIPTION
ADR74 emotes don't work currently, this PR aims to fix that by sending the `profile.emotes` in the `shape.emotes`. 

Current issues with ADR74 emotes:

1) Other players don't see them play
2) The avatar takes a while to load (in the meantime it is shown as a ghost/placeholder)

The 1st issue should be fixed by sending the emotes in the `shape.emotes` property.

The 2nd issue should be fixed by removing the emotes from the `shape.wearables` list, since those failed to be fetch, and it takes a timeout to let the avatar finish loading.

**IMPORTANT:** This will break legacy emotes that are stored as wearables currently in production.