### PR TITLE
feat: ab detection functionality

### DIFF
--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -242,10 +242,21 @@ function initChatCommands() {
     }
   })
 
-  addChatCommand('debug', 'Show debug panel', (_message) => getDebugPanelMessage())
+  addChatCommand('debug', 
+      'Show debug panel', 
+      (_message) => getDebugPanelMessage())
 
-  addChatCommand('showfps', 'Show fps panel (deprecated in favor of /debug)', (_message) => getDebugPanelMessage())
+  addChatCommand('showfps', 
+      'Show fps panel (deprecated in favor of /debug)', 
+      (_message) => getDebugPanelMessage()
+  )
 
+  addChatCommand(
+      'detectabs',
+      'Paint AB-loaded world objects green and GLTF red', 
+      (message) => parseAndSendDetectABMessage(message)
+  )
+  
   addChatCommand('getname', 'Gets your username', (_message) => {
     const currentUserProfile = getCurrentUserProfile(store.getState())
     if (!currentUserProfile) throw new Error('profileNotInitialized')
@@ -460,6 +471,42 @@ function getDebugPanelMessage() {
     messageType: ChatMessageType.SYSTEM,
     timestamp: Date.now(),
     body: 'Toggling FPS counter'
+  }
+}
+
+//message can be
+//null or empty => enable ABs painting for all scenes
+//scene => enable ABs painting for current scene
+//o
+function parseAndSendDetectABMessage(message: string) {
+  
+  let isOn : boolean
+  let forCurrentScene: boolean
+  const offString : string = 'off'
+  const sceneString : string = 'scene'
+  
+  if(message && message.includes(' '))
+  {
+    const words: string[] = message.split(' ')
+    const firstWord: string = words[0].trim()
+    const secondWord: string = words[1].trim()
+    forCurrentScene = firstWord == sceneString
+    isOn = secondWord != offString
+  }
+  else
+  {
+    isOn = message != offString
+    forCurrentScene = message == sceneString
+  }
+
+  getUnityInstance().DetectABs({isOn: isOn, forCurrentScene: forCurrentScene})
+
+  return {
+    messageId: uuid(),
+    sender: 'Decentraland',
+    messageType: ChatMessageType.SYSTEM,
+    timestamp: Date.now(),
+    body: 'Sending detect ABs message'
   }
 }
 

--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -251,6 +251,12 @@ function initChatCommands() {
       (_message) => getDebugPanelMessage()
   )
 
+  /* 
+    /detectabs => enable for all shapes
+    /detectabs off => disable for all shapes
+    /detectabs scene => enable for current scene shapes
+    /detectabs scene off => disable for current scene shapes
+   */
   addChatCommand(
       'detectabs',
       'Paint AB-loaded world objects green and GLTF red', 

--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -242,14 +242,10 @@ function initChatCommands() {
     }
   })
 
-  addChatCommand('debug', 
-      'Show debug panel', 
-      (_message) => getDebugPanelMessage())
+  addChatCommand('debug','Show debug panel',(_message) => getDebugPanelMessage())
 
-  addChatCommand('showfps', 
-      'Show fps panel (deprecated in favor of /debug)', 
-      (_message) => getDebugPanelMessage()
-  )
+  addChatCommand('showfps','Show fps panel (deprecated in favor of /debug)',(_message) => 
+      getDebugPanelMessage())
 
   /* 
     /detectabs => enable for all shapes
@@ -257,11 +253,8 @@ function initChatCommands() {
     /detectabs scene => enable for current scene shapes
     /detectabs scene off => disable for current scene shapes
    */
-  addChatCommand(
-      'detectabs',
-      'Paint AB-loaded world objects green and GLTF red', 
-      (message) => parseAndSendDetectABMessage(message)
-  )
+  addChatCommand('detectabs','Paint AB-loaded world objects green and GLTF red',(message) => 
+      parseAndSendDetectABMessage(message))
   
   addChatCommand('getname', 'Gets your username', (_message) => {
     const currentUserProfile = getCurrentUserProfile(store.getState())
@@ -492,21 +485,18 @@ function parseAndSendDetectABMessage(message: string) {
   const offString : string = 'off'
   const sceneString : string = 'scene'
   
-  if(message && message.includes(' '))
-  {
+  if(message && message.includes(' ')) {
     const words: string[] = message.split(' ')
     const firstWord: string = words[0].trim()
     const secondWord: string = words[1].trim()
-    forCurrentScene = firstWord == sceneString
-    isOn = secondWord != offString
-  }
-  else
-  {
-    isOn = message != offString
-    forCurrentScene = message == sceneString
+    forCurrentScene = firstWord === sceneString
+    isOn = secondWord !== offString
+  } else {
+    isOn = message !== offString
+    forCurrentScene = message === sceneString
   }
 
-  getUnityInstance().DetectABs({isOn: isOn, forCurrentScene: forCurrentScene})
+  getUnityInstance().DetectABs({isOn: isOn, forCurrentScene: forCurrentScene })
 
   return {
     messageId: uuid(),

--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -242,10 +242,9 @@ function initChatCommands() {
     }
   })
 
-  addChatCommand('debug','Show debug panel',(_message) => getDebugPanelMessage())
+  addChatCommand('debug', 'Show debug panel', (_message) => getDebugPanelMessage())
 
-  addChatCommand('showfps','Show fps panel (deprecated in favor of /debug)',(_message) => 
-      getDebugPanelMessage())
+  addChatCommand('showfps', 'Show fps panel (deprecated in favor of /debug)', (_message) => getDebugPanelMessage())
 
   /* 
     /detectabs => enable for all shapes
@@ -254,8 +253,9 @@ function initChatCommands() {
     /detectabs scene off => disable for current scene shapes
    */
   addChatCommand('detectabs', 'Paint AB-loaded world objects green and GLTF red', (message) =>
-      parseAndSendDetectABMessage(message))
-  
+    parseAndSendDetectABMessage(message)
+  )
+
   addChatCommand('getname', 'Gets your username', (_message) => {
     const currentUserProfile = getCurrentUserProfile(store.getState())
     if (!currentUserProfile) throw new Error('profileNotInitialized')
@@ -479,7 +479,6 @@ function getDebugPanelMessage() {
 //off => disable ABs painting for all loaded scenes
 //scene off => disable ABs painting for current scene
 function parseAndSendDetectABMessage(message: string) {
-
   let isOn: boolean
   let forCurrentScene: boolean
   const offString: string = 'off'
@@ -496,7 +495,7 @@ function parseAndSendDetectABMessage(message: string) {
     forCurrentScene = message === sceneString
   }
 
-  getUnityInstance().DetectABs({isOn: isOn, forCurrentScene: forCurrentScene})
+  getUnityInstance().DetectABs({ isOn: isOn, forCurrentScene: forCurrentScene })
 
   return {
     messageId: uuid(),

--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -477,7 +477,8 @@ function getDebugPanelMessage() {
 //message can be
 //null or empty => enable ABs painting for all scenes
 //scene => enable ABs painting for current scene
-//o
+//off => disable ABs painting for all loaded scenes
+//scene off => disable ABs painting for current scene
 function parseAndSendDetectABMessage(message: string) {
   
   let isOn : boolean

--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -253,7 +253,7 @@ function initChatCommands() {
     /detectabs scene => enable for current scene shapes
     /detectabs scene off => disable for current scene shapes
    */
-  addChatCommand('detectabs','Paint AB-loaded world objects green and GLTF red',(message) => 
+  addChatCommand('detectabs', 'Paint AB-loaded world objects green and GLTF red', (message) =>
       parseAndSendDetectABMessage(message))
   
   addChatCommand('getname', 'Gets your username', (_message) => {
@@ -479,13 +479,13 @@ function getDebugPanelMessage() {
 //off => disable ABs painting for all loaded scenes
 //scene off => disable ABs painting for current scene
 function parseAndSendDetectABMessage(message: string) {
-  
-  let isOn : boolean
+
+  let isOn: boolean
   let forCurrentScene: boolean
-  const offString : string = 'off'
-  const sceneString : string = 'scene'
-  
-  if(message && message.includes(' ')) {
+  const offString: string = 'off'
+  const sceneString: string = 'scene'
+
+  if (message && message.includes(' ')) {
     const words: string[] = message.split(' ')
     const firstWord: string = words[0].trim()
     const secondWord: string = words[1].trim()
@@ -496,7 +496,7 @@ function parseAndSendDetectABMessage(message: string) {
     forCurrentScene = message === sceneString
   }
 
-  getUnityInstance().DetectABs({isOn: isOn, forCurrentScene: forCurrentScene })
+  getUnityInstance().DetectABs({isOn: isOn, forCurrentScene: forCurrentScene})
 
   return {
     messageId: uuid(),

--- a/packages/unity-interface/IUnityInterface.ts
+++ b/packages/unity-interface/IUnityInterface.ts
@@ -101,6 +101,7 @@ export interface IUnityInterface {
   SetSceneDebugPanel(): void
   ShowFPSPanel(): void
   HideFPSPanel(): void
+  DetectABs(data: {isOn: boolean, forCurrentScene: boolean }): void
   SetEngineDebugPanel(): void
   SetDisableAssetBundles(): void
   CrashPayloadRequest(): Promise<string>

--- a/packages/unity-interface/IUnityInterface.ts
+++ b/packages/unity-interface/IUnityInterface.ts
@@ -101,7 +101,7 @@ export interface IUnityInterface {
   SetSceneDebugPanel(): void
   ShowFPSPanel(): void
   HideFPSPanel(): void
-  DetectABs(data: {isOn: boolean; forCurrentScene: boolean }): void
+  DetectABs(data: { isOn: boolean; forCurrentScene: boolean }): void
   SetEngineDebugPanel(): void
   SetDisableAssetBundles(): void
   CrashPayloadRequest(): Promise<string>

--- a/packages/unity-interface/IUnityInterface.ts
+++ b/packages/unity-interface/IUnityInterface.ts
@@ -101,7 +101,7 @@ export interface IUnityInterface {
   SetSceneDebugPanel(): void
   ShowFPSPanel(): void
   HideFPSPanel(): void
-  DetectABs(data: {isOn: boolean, forCurrentScene: boolean }): void
+  DetectABs(data: {isOn: boolean; forCurrentScene: boolean }): void
   SetEngineDebugPanel(): void
   SetDisableAssetBundles(): void
   CrashPayloadRequest(): Promise<string>

--- a/packages/unity-interface/UnityInterface.ts
+++ b/packages/unity-interface/UnityInterface.ts
@@ -184,7 +184,7 @@ export class UnityInterface implements IUnityInterface {
   }
   
   public DetectABs(data: {isOn: boolean, forCurrentScene: boolean }) {
-    this.SendMessageToUnity('Main', 'DetectABs', JSON.stringify(data))
+    this.SendMessageToUnity('Bridges', 'DetectABs', JSON.stringify(data))
   }
 
   public HideFPSPanel() {

--- a/packages/unity-interface/UnityInterface.ts
+++ b/packages/unity-interface/UnityInterface.ts
@@ -182,6 +182,10 @@ export class UnityInterface implements IUnityInterface {
   public ShowFPSPanel() {
     this.SendMessageToUnity('Main', 'ShowFPSPanel')
   }
+  
+  public DetectABs(data: {isOn: boolean, forCurrentScene: boolean }) {
+    this.SendMessageToUnity('Main', 'DetectABs', JSON.stringify(data))
+  }
 
   public HideFPSPanel() {
     this.SendMessageToUnity('Main', 'HideFPSPanel')

--- a/packages/unity-interface/UnityInterface.ts
+++ b/packages/unity-interface/UnityInterface.ts
@@ -183,7 +183,7 @@ export class UnityInterface implements IUnityInterface {
     this.SendMessageToUnity('Main', 'ShowFPSPanel')
   }
   
-  public DetectABs(data: {isOn: boolean, forCurrentScene: boolean }) {
+  public DetectABs(data: {isOn: boolean; forCurrentScene: boolean }) {
     this.SendMessageToUnity('Bridges', 'DetectABs', JSON.stringify(data))
   }
 

--- a/packages/unity-interface/UnityInterface.ts
+++ b/packages/unity-interface/UnityInterface.ts
@@ -182,8 +182,8 @@ export class UnityInterface implements IUnityInterface {
   public ShowFPSPanel() {
     this.SendMessageToUnity('Main', 'ShowFPSPanel')
   }
-  
-  public DetectABs(data: {isOn: boolean; forCurrentScene: boolean }) {
+
+  public DetectABs(data: { isOn: boolean; forCurrentScene: boolean }) {
     this.SendMessageToUnity('Bridges', 'DetectABs', JSON.stringify(data))
   }
 


### PR DESCRIPTION
# What? <!-- what is this PR? -->

This PR adds a new chat command to send a message to Unity to detect which shapes are loaded as ABs and which as raw GLTFs. Command supports arguments to enable/disable shape coloring and to make the coloring local to current scene.

It is supposed to be tested together with Renderer PR:
https://github.com/decentraland/unity-renderer/pull/3099
Which closes this issue:
https://github.com/decentraland/unity-renderer/issues/2911

New chat commands are:

/detectabs => enable for all shapes
/detectabs off => disable for all shapes
/detectabs scene => enable for current scene shapes
/detectabs scene off => disable for current scene shapes (works only if "/decetabs scene" was used for this scene to enable) 

# Why? <!-- Explain the reason -->

We need this debug tool in order to easily see if the shape was not converted to AB for some reason and also it will be simpler to understand how fast the conversion happens.
