### PR TITLE
chore: remove naive chat sanitization

### DIFF
--- a/packages/unity-interface/UnityInterface.ts
+++ b/packages/unity-interface/UnityInterface.ts
@@ -328,11 +328,6 @@ export class UnityInterface implements IUnityInterface {
   }
 
   public AddMessageToChatWindow(message: ChatMessage) {
-    try {
-      message.body = message.body.replace(/</g, 'ᐸ').replace(/>/g, 'ᐳ')
-    } catch (err: any) {
-      unityLogger.error(err)
-    }
     if (message.body.length > 1000) {
       trackEvent('long_chat_message_ignored', { message: message.body, sender: message.sender })
       return


### PR DESCRIPTION
Unity is already ignoring rich text labels. Removing `<` `>` is not needed anymore.

## Test
- Now you can type <3 ❤️ .
- tags such as `<size=80>text</size>` should be ignored as rich text. Disclaimer: The input box is not ignoring them, that's something to be fixed in unity.