### PR TITLE
fix: lazy-loading fixes

### DIFF
--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -206,8 +206,10 @@ function* configureMatrixClient(action: SetMatrixClient) {
       if (userId) {
         // When it's a friend and is not added to catalog
         // unity needs to know this information to show that the user has connected
-        if (isFriend(store.getState(), userId) && !isAddedToCatalog(store.getState(), userId)) {
+        if (!isAddedToCatalog(store.getState(), userId)) {
           await ensureFriendProfile(userId)
+        }
+        if (isFriend(store.getState(), userId)) {
           getUnityInstance().AddFriends({
             friends: [userId],
             totalFriends: getTotalFriends(store.getState())

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -748,12 +748,22 @@ function* initializeStatusUpdateInterval() {
       continue
     }
 
-    const domain = client.getDomain()
-
     const rawFriends: string[] = yield select(getPrivateMessagingFriends)
 
     const friends = rawFriends.map((x) => {
-      return `@${x}:${domain}`
+      return getMatrixIdFromUser(x)
+    })
+
+    // When it's a friend and is not added to catalog
+    // unity needs to know this information to show that the user has connected
+    friends.forEach(async (friend) => {
+      if (!isAddedToCatalog(store.getState(), friend)) {
+        await ensureFriendProfile(friend)
+      }
+      getUnityInstance().AddFriends({
+        friends: [friend],
+        totalFriends: getTotalFriends(store.getState())
+      })
     })
 
     updateUserStatus(client, ...friends)

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -220,10 +220,10 @@ function* configureMatrixClient(action: SetMatrixClient) {
       if (userId) {
         // When it's a friend and is not added to catalog
         // unity needs to know this information to show that the user has connected
-        if (!isAddedToCatalog(store.getState(), userId)) {
-          await ensureFriendProfile(userId)
-        }
         if (isFriend(store.getState(), userId)) {
+          if (!isAddedToCatalog(store.getState(), userId)) {
+            await ensureFriendProfile(userId)
+          }
           getUnityInstance().AddFriends({
             friends: [userId],
             totalFriends: getTotalFriends(store.getState())
@@ -766,21 +766,7 @@ function* initializeStatusUpdateInterval() {
 
     const rawFriends: string[] = yield select(getPrivateMessagingFriends)
 
-    const friends = rawFriends.map((x) => {
-      return getMatrixIdFromUser(x)
-    })
-
-    // When it's a friend and is not added to catalog
-    // unity needs to know this information to show that the user has connected
-    friends.forEach(async (friend) => {
-      if (!isAddedToCatalog(store.getState(), friend)) {
-        await ensureFriendProfile(friend)
-      }
-      getUnityInstance().AddFriends({
-        friends: [friend],
-        totalFriends: getTotalFriends(store.getState())
-      })
-    })
+    const friends = rawFriends.map((x) => getMatrixIdFromUser(x))
 
     updateUserStatus(client, ...friends)
 

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -642,10 +642,10 @@ export function getFriendsWithDirectMessages(request: GetFriendsWithDirectMessag
     return
   }
 
-  const friendsIds: string[] = getPrivateMessagingFriends(store.getState()).slice(
-    request.skip,
-    request.skip + request.limit
-  )
+  const friendsIds: string[] = conversationsWithMessages
+    .slice(request.skip, request.skip + request.limit)
+    .map((conv) => conv.conversation.userIds![1])
+
   const filteredFriends: Array<ProfileUserInfo> = getProfilesFromStore(
     store.getState(),
     friendsIds,

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -671,7 +671,7 @@ export function getFriendsWithDirectMessages(request: GetFriendsWithDirectMessag
       lastMessageTimestamp: friend.conversation.lastEventTimestamp!,
       userId: friend.userId
     })),
-    totalFriendsWithDirectMessages: friendsConversations.length
+    totalFriendsWithDirectMessages: conversationsWithMessages.length
   }
 
   const profilesForRenderer = friendsConversations.map((friend) => profileToRendererFormat(friend.avatar, {}))

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -573,8 +573,8 @@ export function getFriendRequests(request: GetFriendRequestsPayload) {
   const addFriendRequestsPayload: AddFriendRequestsPayload = {
     requestedTo: toFriendRequests.map((friend) => friend.userId),
     requestedFrom: fromFriendRequests.map((friend) => friend.userId),
-    totalReceivedFriendRequests: fromFriendRequests.length,
-    totalSentFriendRequests: toFriendRequests.length
+    totalReceivedFriendRequests: friends.fromFriendRequests.length,
+    totalSentFriendRequests: friends.toFriendRequests.length
   }
 
   // get friend requests profiles

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -247,8 +247,8 @@ describe('Friends sagas', () => {
         const addedFriendRequests = {
           requestedTo: friendsFromStore.toFriendRequests.map((friend) => friend.userId),
           requestedFrom: friendsFromStore.fromFriendRequests.map((friend) => friend.userId),
-          totalReceivedFriendRequests: 1,
-          totalSentFriendRequests: 1
+          totalReceivedFriendRequests: friendsFromStore.fromFriendRequests.length,
+          totalSentFriendRequests: friendsFromStore.toFriendRequests.length
         }
 
         const expectedFriends: AddUserProfilesToCatalogPayload = {
@@ -277,8 +277,8 @@ describe('Friends sagas', () => {
         const addedFriendRequests = {
           requestedTo: friendsFromStore.toFriendRequests.slice(5).map((friend) => friend.userId),
           requestedFrom: friendsFromStore.fromFriendRequests.slice(5).map((friend) => friend.userId),
-          totalReceivedFriendRequests: 0,
-          totalSentFriendRequests: 0
+          totalReceivedFriendRequests: friendsFromStore.fromFriendRequests.length,
+          totalSentFriendRequests: friendsFromStore.toFriendRequests.length
         }
 
         const expectedFriends: AddUserProfilesToCatalogPayload = {

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -320,7 +320,7 @@ describe('Friends sagas', () => {
               userId: profilesFromStore[1].data.userId
             }
           ],
-          totalFriendsWithDirectMessages: 1
+          totalFriendsWithDirectMessages: allCurrentConversations.length
         }
 
         sinon.mock(getUnityInstance()).expects('AddUserProfilesToCatalog').once().withExactArgs(expectedFriends)


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->
Closes #541 

# What? <!-- what is this PR? -->

- [x]  For `totalFriendsWithDirectMessages` we're sending the same value as the requested one, instead of the actual value of the total friends with DMs.

- [x]  For `totalReceivedFriendRequests` and `totalSentFriendRequests` we're sending the same value as the requested one, instead of the actual value of total requests.

- [x] Pagination does not work in `AddFriendsWithDirectMessages`.
