### PR TITLE
feat: Remove old emoteDataV0 in favor of emoteDataADR74

### DIFF
--- a/packages/shared/catalogs/sagas.ts
+++ b/packages/shared/catalogs/sagas.ts
@@ -342,7 +342,7 @@ async function fetchWearablesByCollectionFromPreviewMode(filters: WearablesReque
  * We are now mapping wearables that were fetched from the builder server into the same format that is returned by the catalysts
  */
 function mapUnpublishedItemIntoCatalystItem(action: EmotesRequest | WearablesRequest, item: UnpublishedWearable): any {
-  const { id, rarity, name, thumbnail, description, data, contents: contentToHash, type } = item
+  const { id, rarity, name, thumbnail, description, data, contents: contentToHash } = item
   const baseItem = {
     id,
     rarity,

--- a/packages/shared/catalogs/sagas.ts
+++ b/packages/shared/catalogs/sagas.ts
@@ -362,7 +362,6 @@ function mapUnpublishedItemIntoCatalystItem(action: EmotesRequest | WearablesReq
   if (action.type === WEARABLES_REQUEST) {
     return {
       ...baseItem,
-      emoteDataV0: type === UnpublishedWearableType.EMOTE ? { loop: data.category === 'loop' } : undefined,
       data: {
         ...data,
         representations
@@ -390,7 +389,7 @@ function mapCatalystRepresentationIntoV2(representation: any): BodyShapeRepresen
 }
 
 function mapCatalystItemIntoV2(v2Item: PartialItem): PartialItem {
-  const { id, rarity, i18n, thumbnail, description, emoteDataV0 } = v2Item
+  const { id, rarity, i18n, thumbnail, description } = v2Item
   let data
   if (isPartialWearable(v2Item)) {
     data = v2Item.data
@@ -413,8 +412,7 @@ function mapCatalystItemIntoV2(v2Item: PartialItem): PartialItem {
       ...data,
       representations: newRepresentations
     },
-    baseUrl,
-    emoteDataV0
+    baseUrl
   }
 }
 

--- a/packages/shared/catalogs/types.ts
+++ b/packages/shared/catalogs/types.ts
@@ -68,15 +68,10 @@ export type WearableV2 = {
   baseUrl: string
   baseUrlBundles: string
   menuBarIcon?: string
-  emoteDataV0?: EmoteDataV0
 }
 
 export type Emote = Omit<WearableV2, 'data'> & {
   emoteDataADR74: Omit<EmoteDataADR74, 'contents'> & { contents: KeyAndHash[] }
-}
-
-export type EmoteDataV0 = {
-  loop: boolean
 }
 
 export type BodyShapeRepresentationV2 = {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Remove support for legacy emotes

# Why? <!-- Explain the reason -->
All emotes were successfully migrated to the new emoteDataADR74 schema
