### PR TITLE
chore: bump `dcl-social-client` version to 1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "dcl-catalyst-client": "^12.1.3",
         "dcl-quests-client": "^2.10.0",
         "dcl-scene-writer": "^1.1.2",
-        "dcl-social-client": "^1.11.2",
+        "dcl-social-client": "^1.12.0",
         "decentraland-ecs": "^6.0.4",
         "decentraland-rpc": "^3.1.9",
         "devtools-protocol": "0.0.615714",
@@ -2640,12 +2640,9 @@
       }
     },
     "node_modules/base-x": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
@@ -2986,11 +2983,11 @@
       }
     },
     "node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
-        "base-x": "^3.0.2"
+        "base-x": "^4.0.0"
       }
     },
     "node_modules/buffer": {
@@ -3740,14 +3737,14 @@
       }
     },
     "node_modules/dcl-social-client": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.11.2.tgz",
-      "integrity": "sha512-tDhCiFtvx49sJYzprfjznd4zU14/5XGU2vboSen8sTayUE7EJBhYAjVAFvjBbzMxdpy7R5QkisjaCJ9YULfv1Q==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.12.0.tgz",
+      "integrity": "sha512-SptkDQLTY1WVQSS5ZfpBFTb2G5+neW5Duvrjuo8jT9OG3OO10kC43R3KHpvjiZozcONHHRwr1fASr0W1WepENQ==",
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
         "@types/matrix-js-sdk": "11.0.1",
         "@types/node": "^13.11.1",
-        "matrix-js-sdk": "16.0.0"
+        "matrix-js-sdk": "20.0.2"
       }
     },
     "node_modules/dcl-social-client/node_modules/@types/node": {
@@ -7560,21 +7557,24 @@
       "integrity": "sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA=="
     },
     "node_modules/matrix-js-sdk": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-16.0.0.tgz",
-      "integrity": "sha512-ZlrRjqo493pY6OwtQto+oNG2tFALbJKHUtIHUbay0eX100jQjbgMzXtWHrrFEU01+/aAccx+UP4ap0/MRcsALQ==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-20.0.2.tgz",
+      "integrity": "sha512-PZMiLQHtmV+c5wZxS7EyWUKgHMJ/Syad7S5RxZVg80wug3qlX3oXkfyxZwrcMK4T1xE31upizspTZLm5Bkl2Vw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "another-json": "^0.2.0",
         "browser-request": "^0.3.3",
-        "bs58": "^4.0.1",
+        "bs58": "^5.0.0",
         "content-type": "^1.0.4",
         "loglevel": "^1.7.1",
         "matrix-events-sdk": "^0.0.1-beta.7",
-        "p-retry": "^4.5.0",
+        "p-retry": "4",
         "qs": "^6.9.6",
         "request": "^2.88.2",
         "unhomoglyph": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=12.9.0"
       }
     },
     "node_modules/md5-file": {
@@ -14688,12 +14688,9 @@
       }
     },
     "base-x": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "base64-js": {
       "version": "1.3.1",
@@ -14946,11 +14943,11 @@
       }
     },
     "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "requires": {
-        "base-x": "^3.0.2"
+        "base-x": "^4.0.0"
       }
     },
     "buffer": {
@@ -15562,14 +15559,14 @@
       "requires": {}
     },
     "dcl-social-client": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.11.2.tgz",
-      "integrity": "sha512-tDhCiFtvx49sJYzprfjznd4zU14/5XGU2vboSen8sTayUE7EJBhYAjVAFvjBbzMxdpy7R5QkisjaCJ9YULfv1Q==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.12.0.tgz",
+      "integrity": "sha512-SptkDQLTY1WVQSS5ZfpBFTb2G5+neW5Duvrjuo8jT9OG3OO10kC43R3KHpvjiZozcONHHRwr1fASr0W1WepENQ==",
       "requires": {
         "@dcl/crypto": "^3.0.1",
         "@types/matrix-js-sdk": "11.0.1",
         "@types/node": "^13.11.1",
-        "matrix-js-sdk": "16.0.0"
+        "matrix-js-sdk": "20.0.2"
       },
       "dependencies": {
         "@types/node": {
@@ -18528,18 +18525,18 @@
       "integrity": "sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA=="
     },
     "matrix-js-sdk": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-16.0.0.tgz",
-      "integrity": "sha512-ZlrRjqo493pY6OwtQto+oNG2tFALbJKHUtIHUbay0eX100jQjbgMzXtWHrrFEU01+/aAccx+UP4ap0/MRcsALQ==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-20.0.2.tgz",
+      "integrity": "sha512-PZMiLQHtmV+c5wZxS7EyWUKgHMJ/Syad7S5RxZVg80wug3qlX3oXkfyxZwrcMK4T1xE31upizspTZLm5Bkl2Vw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "another-json": "^0.2.0",
         "browser-request": "^0.3.3",
-        "bs58": "^4.0.1",
+        "bs58": "^5.0.0",
         "content-type": "^1.0.4",
         "loglevel": "^1.7.1",
         "matrix-events-sdk": "^0.0.1-beta.7",
-        "p-retry": "^4.5.0",
+        "p-retry": "4",
         "qs": "^6.9.6",
         "request": "^2.88.2",
         "unhomoglyph": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "dcl-catalyst-client": "^12.1.3",
     "dcl-quests-client": "^2.10.0",
     "dcl-scene-writer": "^1.1.2",
-    "dcl-social-client": "^1.11.2",
+    "dcl-social-client": "^1.12.0",
     "decentraland-ecs": "^6.0.4",
     "decentraland-rpc": "^3.1.9",
     "devtools-protocol": "0.0.615714",


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Bump `dcl-social-client` version to 1.12.0 which includes an improvement on initial load, making use of a cache (IndexedDB)

# Why? <!-- Explain the reason -->
The idea about this change is to persist Matrix sessions to avoid re-sync on every login.
