### PR TITLE
fix: send partial profiles to explorer to show up chat windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "dcl-catalyst-client": "^13.0.7",
         "dcl-quests-client": "^2.10.0",
         "dcl-scene-writer": "^1.1.2",
-        "dcl-social-client": "^1.15.2",
+        "dcl-social-client": "^1.17.0",
         "decentraland-ecs": "^6.0.4",
         "decentraland-rpc": "^3.1.9",
         "devtools-protocol": "0.0.615714",
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/dcl-social-client": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.15.2.tgz",
-      "integrity": "sha512-9+MDwy0UPU4am88lRbubaEMzKAcyvtZ4d/Kvbqdum4z+UzTTuNBKK0xwHzR86qPqBJDgqFR7EBsK1V6t2kalhQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.17.0.tgz",
+      "integrity": "sha512-Bb4ElSxUOYEqE+nbYPqm5rnqGt2vFysHd+RyFnX4oBczE0wqgmJPTNLgZvHyBXCnL+16yyzXfxIkIASFzmaywQ==",
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
         "@types/matrix-js-sdk": "11.0.1",
@@ -14954,9 +14954,9 @@
       "requires": {}
     },
     "dcl-social-client": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.15.2.tgz",
-      "integrity": "sha512-9+MDwy0UPU4am88lRbubaEMzKAcyvtZ4d/Kvbqdum4z+UzTTuNBKK0xwHzR86qPqBJDgqFR7EBsK1V6t2kalhQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.17.0.tgz",
+      "integrity": "sha512-Bb4ElSxUOYEqE+nbYPqm5rnqGt2vFysHd+RyFnX4oBczE0wqgmJPTNLgZvHyBXCnL+16yyzXfxIkIASFzmaywQ==",
       "requires": {
         "@dcl/crypto": "^3.0.1",
         "@types/matrix-js-sdk": "11.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "dcl-catalyst-client": "^13.0.7",
         "dcl-quests-client": "^2.10.0",
         "dcl-scene-writer": "^1.1.2",
-        "dcl-social-client": "^1.17.0",
+        "dcl-social-client": "^1.17.1",
         "decentraland-ecs": "^6.0.4",
         "decentraland-rpc": "^3.1.9",
         "devtools-protocol": "0.0.615714",
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/dcl-social-client": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.17.0.tgz",
-      "integrity": "sha512-Bb4ElSxUOYEqE+nbYPqm5rnqGt2vFysHd+RyFnX4oBczE0wqgmJPTNLgZvHyBXCnL+16yyzXfxIkIASFzmaywQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.17.1.tgz",
+      "integrity": "sha512-vPZ6ia3P7czfOH4Q82OZm5iq058kXxX9/n96R2FlTaxJ8z+gcH0sk1T9FD17TMWtY8xtjbVBsEQmS71oMFcPmA==",
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
         "@types/matrix-js-sdk": "11.0.1",
@@ -14954,9 +14954,9 @@
       "requires": {}
     },
     "dcl-social-client": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.17.0.tgz",
-      "integrity": "sha512-Bb4ElSxUOYEqE+nbYPqm5rnqGt2vFysHd+RyFnX4oBczE0wqgmJPTNLgZvHyBXCnL+16yyzXfxIkIASFzmaywQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.17.1.tgz",
+      "integrity": "sha512-vPZ6ia3P7czfOH4Q82OZm5iq058kXxX9/n96R2FlTaxJ8z+gcH0sk1T9FD17TMWtY8xtjbVBsEQmS71oMFcPmA==",
       "requires": {
         "@dcl/crypto": "^3.0.1",
         "@types/matrix-js-sdk": "11.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "dcl-catalyst-client": "^13.0.7",
         "dcl-quests-client": "^2.10.0",
         "dcl-scene-writer": "^1.1.2",
-        "dcl-social-client": "^1.14.2",
+        "dcl-social-client": "^1.15.2",
         "decentraland-ecs": "^6.0.4",
         "decentraland-rpc": "^3.1.9",
         "devtools-protocol": "0.0.615714",
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/dcl-social-client": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.14.2.tgz",
-      "integrity": "sha512-RojxnJ8OLY6KJ8VaDsV6VvAKC/mC5FBrkNJ5LGHSb0Vm3WN3uu8QPUdF8JiH7WfCceM3nV0DfBICIpj3Uvdspg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.15.2.tgz",
+      "integrity": "sha512-9+MDwy0UPU4am88lRbubaEMzKAcyvtZ4d/Kvbqdum4z+UzTTuNBKK0xwHzR86qPqBJDgqFR7EBsK1V6t2kalhQ==",
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
         "@types/matrix-js-sdk": "11.0.1",
@@ -14954,9 +14954,9 @@
       "requires": {}
     },
     "dcl-social-client": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.14.2.tgz",
-      "integrity": "sha512-RojxnJ8OLY6KJ8VaDsV6VvAKC/mC5FBrkNJ5LGHSb0Vm3WN3uu8QPUdF8JiH7WfCceM3nV0DfBICIpj3Uvdspg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.15.2.tgz",
+      "integrity": "sha512-9+MDwy0UPU4am88lRbubaEMzKAcyvtZ4d/Kvbqdum4z+UzTTuNBKK0xwHzR86qPqBJDgqFR7EBsK1V6t2kalhQ==",
       "requires": {
         "@dcl/crypto": "^3.0.1",
         "@types/matrix-js-sdk": "11.0.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "dcl-catalyst-client": "^13.0.7",
     "dcl-quests-client": "^2.10.0",
     "dcl-scene-writer": "^1.1.2",
-    "dcl-social-client": "^1.17.0",
+    "dcl-social-client": "^1.17.1",
     "decentraland-ecs": "^6.0.4",
     "decentraland-rpc": "^3.1.9",
     "devtools-protocol": "0.0.615714",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "dcl-catalyst-client": "^13.0.7",
     "dcl-quests-client": "^2.10.0",
     "dcl-scene-writer": "^1.1.2",
-    "dcl-social-client": "^1.14.2",
+    "dcl-social-client": "^1.15.2",
     "decentraland-ecs": "^6.0.4",
     "decentraland-rpc": "^3.1.9",
     "devtools-protocol": "0.0.615714",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "dcl-catalyst-client": "^13.0.7",
     "dcl-quests-client": "^2.10.0",
     "dcl-scene-writer": "^1.1.2",
-    "dcl-social-client": "^1.15.2",
+    "dcl-social-client": "^1.17.0",
     "decentraland-ecs": "^6.0.4",
     "decentraland-rpc": "^3.1.9",
     "devtools-protocol": "0.0.615714",

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -58,7 +58,7 @@ import {
   GetChannelsPayload,
   ChannelSearchResultsPayload,
   JoinOrCreateChannelPayload,
-  ChannelMemberProfile
+  ChannelMember
 } from 'shared/types'
 import { Realm } from 'shared/dao/types'
 import { lastPlayerPosition } from 'shared/world/positionThings'
@@ -1632,7 +1632,7 @@ export async function getChannelMessages(request: GetChannelMessagesPayload) {
   getUnityInstance().AddChatMessages(addChatMessages)
 }
 
-function findMissingMembers(members: ChannelMemberProfile[], ownId: string) {
+function findMissingMembers(members: ChannelMember[], ownId: string) {
   return members.filter((member) => {
     const localUserId = getUserIdFromMatrix(member.userId)
     return member.userId !== ownId && !isAddedToCatalog(store.getState(), localUserId)
@@ -1640,7 +1640,7 @@ function findMissingMembers(members: ChannelMemberProfile[], ownId: string) {
 }
 
 function getMembers(client: SocialAPI, userIds: string[], channelId: string) {
-  return userIds.map((userId): ChannelMemberProfile => {
+  return userIds.map((userId): ChannelMember => {
     const memberInfo = client.getMemberInfo(channelId, userId)
     return { userId, name: memberInfo.displayName ?? '' }
   })
@@ -1903,7 +1903,7 @@ export function getChannelMembers(request: GetChannelMembersPayload) {
  * Checks which members are present in the profile catalog and sends partial profiles for missing users
  * @param members is an array of [member ID, name]
  */
-function sendMissingProfiles(members: ChannelMemberProfile[], ownId: string) {
+function sendMissingProfiles(members: ChannelMember[], ownId: string) {
   // find missing users
   const missingUsers = findMissingMembers(members, ownId)
 
@@ -1913,11 +1913,11 @@ function sendMissingProfiles(members: ChannelMemberProfile[], ownId: string) {
   }
 }
 
-function getMissingProfiles(missingUsers: ChannelMemberProfile[]): NewProfileForRenderer[] {
+function getMissingProfiles(missingUsers: ChannelMember[]): NewProfileForRenderer[] {
   return missingUsers.map((missingUser) => buildMissingProfile(missingUser))
 }
 
-function buildMissingProfile(user: ChannelMemberProfile) {
+function buildMissingProfile(user: ChannelMember) {
   const localpart = getUserIdFromMatrix(user.userId)
   return defaultProfile({
     userId: localpart,

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -396,12 +396,18 @@ function* configureMatrixClient(action: SetMatrixClient) {
           break
         }
 
+        let onlineMembers = 0
+        if (conversation.userIds) {
+          const userStatuses = client.getUserStatuses(...conversation.userIds)
+          onlineMembers += [...userStatuses.values()].filter((status) => status.presence === PresenceType.ONLINE).length
+        }
+
         const channel: ChannelInfoPayload = {
           name: getNormalizedRoomName(conversation.name),
           channelId: conversation.id,
           unseenMessages: conversation.unreadMessages?.length ?? 0,
           lastMessageTimestamp: conversation.lastEventTimestamp ?? undefined,
-          memberCount: conversation.userIds?.length ?? 1,
+          memberCount: onlineMembers,
           description: '',
           joined: true,
           muted: false

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -1788,12 +1788,18 @@ export function getChannelInfo(request: GetChannelInfoPayload) {
     if (!channel) continue
 
     const muted = profile?.muted?.includes(channelId) ?? false
+
+    let onlineMembers = 1
+    if (channel.userIds) {
+      const userStatuses = client.getUserStatuses(...channel.userIds)
+      onlineMembers += Object.values(userStatuses).filter((status) => status.presence === PresenceType.ONLINE).length
+    }
     channels.push({
       name: getNormalizedRoomName(channel.name || ''),
       channelId: channel.id,
       unseenMessages: muted ? 0 : channel.unreadMessages?.length || 0,
       lastMessageTimestamp: channel.lastEventTimestamp || undefined,
-      memberCount: channel.userIds?.length || 0,
+      memberCount: onlineMembers,
       description: '',
       joined: true,
       muted
@@ -1834,15 +1840,17 @@ export function getChannelMembers(request: GetChannelMembersPayload) {
   }
   const userStatuses = client.getUserStatuses(...(channelMemberIds ?? []))
 
+  const ownId = client.getUserId()
   for (const member of channelMemberIds) {
     const userId = getUserIdFromMatrix(member)
-    channelMembers.members.push({
-      userId,
-      isOnline: userStatuses.get(member)?.presence === PresenceType.ONLINE
-    })
+    if (ownId === member || userStatuses.get(userId)?.presence === PresenceType.ONLINE) {
+      channelMembers.members.push({
+        userId,
+        isOnline: true
+      })
+    }
   }
 
-  const ownId = client.getUserId()
   // those profiles that are not in the store are prepared without any data but avatar url and name
   const missingUsersIds = channelMemberIds.filter(
     (id) => id !== ownId && !isAddedToCatalog(store.getState(), getUserIdFromMatrix(id))

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -1789,7 +1789,7 @@ export function getChannelInfo(request: GetChannelInfoPayload) {
 
     const muted = profile?.muted?.includes(channelId) ?? false
     channels.push({
-      name: channel.name || '',
+      name: getNormalizedRoomName(channel.name || ''),
       channelId: channel.id,
       unseenMessages: muted ? 0 : channel.unreadMessages?.length || 0,
       lastMessageTimestamp: channel.lastEventTimestamp || undefined,

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -1775,12 +1775,18 @@ export function muteChannel(muteChannel: MuteChannelPayload) {
     store.dispatch(unmutePlayers([channelId]))
   }
 
+  let onlineMembers = 0
+  if (channel.userIds) {
+    const userStatuses = client.getUserStatuses(...channel.userIds)
+    onlineMembers += [...userStatuses.values()].filter((status) => status.presence === PresenceType.ONLINE).length
+  }
+
   const channelInfo: ChannelInfoPayload = {
     name: channel.name ?? '',
     channelId: channel.id,
     unseenMessages: channel.unreadMessages?.length ?? 0,
     lastMessageTimestamp: channel.lastEventTimestamp ?? undefined,
-    memberCount: channel.userIds?.length ?? 1,
+    memberCount: onlineMembers,
     description: '',
     joined: true,
     muted: muteChannel.muted

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -1824,14 +1824,12 @@ export function getChannelMembers(request: GetChannelMembersPayload) {
   const membersIds = channelMemberIds.map((id) => getUserIdFromMatrix(id))
   const profilesFromStore = getProfilesFromStore(store.getState(), membersIds, request.userName)
 
-  for (const profile of profilesFromStore) {
-    const member = channelMemberIds.find((id) => getUserIdFromMatrix(id) === profile.data.userId)
-    if (member) {
-      channelMembers.members.push({
-        userId: getUserIdFromMatrix(member),
-        isOnline: userStatuses.get(member)?.presence === PresenceType.ONLINE
-      })
-    }
+  for (const member of channelMemberIds) {
+    const userId = getUserIdFromMatrix(member)
+    channelMembers.members.push({
+      userId,
+      isOnline: userStatuses.get(member)?.presence === PresenceType.ONLINE
+    })
   }
 
   const profilesForRenderer = profilesFromStore.map((profile) =>
@@ -1842,7 +1840,7 @@ export function getChannelMembers(request: GetChannelMembersPayload) {
 
   // those profiles that are not in the store are prepared without any data but avatar url and name
   const storedIds = profilesFromStore.map((profile) => profile.data.userId)
-  const missingUsersIds = channelMemberIds.filter((id) => !storedIds.includes(id))
+  const missingUsersIds = channelMemberIds.filter((id) => !storedIds.includes(getUserIdFromMatrix(id)))
   const missingProfilesForRenderer = getMissingProfiles(client, request.channelId, missingUsersIds, fetchContentServer)
 
   getUnityInstance().AddUserProfilesToCatalog({ users: [...profilesForRenderer, ...missingProfilesForRenderer] })

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -1571,11 +1571,14 @@ export async function getChannelMessages(request: GetChannelMessagesPayload) {
     const index = messages.map((messages) => messages.id).indexOf(messageId)
     messages.splice(index)
   }
-
+  const ownId = client.getUserId()
   const fetchContentServer = getFetchContentUrlPrefix(store.getState())
   const missingUserIds = messages
     .map((message) => message.sender)
-    .filter((userId) => !isAddedToCatalog(store.getState(), getUserIdFromMatrix(userId)))
+    .filter((userId) => {
+      const localUserId = getUserIdFromMatrix(userId)
+      return userId !== ownId && !isAddedToCatalog(store.getState(), localUserId)
+    })
 
   if (missingUserIds.length > 0) {
     const missingUsers = getMissingProfiles(client, request.channelId, missingUserIds, fetchContentServer)

--- a/packages/shared/friends/utils.ts
+++ b/packages/shared/friends/utils.ts
@@ -1,6 +1,7 @@
 import { getFeatureFlagEnabled, getFeatureFlagVariantValue } from 'shared/meta/selectors'
 import { RootMetaState } from 'shared/meta/types'
 import { store } from 'shared/store/isolatedStore'
+import { UsersAllowed } from 'shared/types'
 
 /**
  * Get the local part of the userId from matrixUserId
@@ -56,6 +57,16 @@ export function areChannelsEnabled(): boolean {
 
 export const DEFAULT_MAX_CHANNELS_VALUE = 5
 
+/*
+ * Returns the maximum allowed number of channels a user can join.
+ */
 export function getMaxChannels(store: RootMetaState): number {
   return (getFeatureFlagVariantValue(store, 'max_joined_channels') as number) ?? DEFAULT_MAX_CHANNELS_VALUE
+}
+
+/*
+ * Returns a list of users who are allowed to create channels.
+ */
+export function getUsersAllowedToCreate(store: RootMetaState): UsersAllowed | undefined {
+  return getFeatureFlagVariantValue(store, 'users_allowed_to_create_channels') as UsersAllowed | undefined
 }

--- a/packages/shared/meta/types.ts
+++ b/packages/shared/meta/types.ts
@@ -26,6 +26,8 @@ export type FeatureFlagsName =
   | 'matrix_disabled' // disable matrix integration entirely
   | 'matrix_presence_disabled' // disable matrix presence feature
   | 'matrix_channels_enabled' // enables matrix channels feature
+  | 'max_joined_channels' // the max amount of joined channels allowed per user
+  | 'users_allowed_to_create_channels' // users who are allowed to create channels
   | 'builder_in_world'
   | 'avatar_lods'
   | 'asset_bundles'
@@ -38,7 +40,6 @@ export type FeatureFlagsName =
   | 'web_cap_fps' // caps the web client FPS
   | 'disabled-catalyst'
   | 'livekit-voicechat'
-  | 'max_joined_channels' // the max amount of joined channels allowed per user
 
 export type BannedUsers = Record<string, Ban[]>
 

--- a/packages/shared/profiles/sagas.ts
+++ b/packages/shared/profiles/sagas.ts
@@ -343,7 +343,7 @@ function* readProfileFromLocalStorage() {
   }
 }
 
-async function buildSnapshotContent(selector: string, value: string) {
+export async function buildSnapshotContent(selector: string, value: string) {
   let hash: string
   let contentFile: ContentFile | undefined
 

--- a/packages/shared/profiles/sagas.ts
+++ b/packages/shared/profiles/sagas.ts
@@ -343,7 +343,7 @@ function* readProfileFromLocalStorage() {
   }
 }
 
-export async function buildSnapshotContent(selector: string, value: string) {
+async function buildSnapshotContent(selector: string, value: string) {
   let hash: string
   let contentFile: ContentFile | undefined
 

--- a/packages/shared/profiles/transformations/profileToRendererFormat.ts
+++ b/packages/shared/profiles/transformations/profileToRendererFormat.ts
@@ -93,7 +93,7 @@ function prepareAvatar(avatar?: Partial<AvatarInfo>) {
 }
 
 // Ensure all snapshots are URLs
-export function prepareSnapshots({ face256, body }: Snapshots): NewProfileForRenderer['snapshots'] {
+function prepareSnapshots({ face256, body }: Snapshots): NewProfileForRenderer['snapshots'] {
   // TODO: move this logic to unity-renderer
   function prepare(value: string) {
     if (value === null || value === undefined) {

--- a/packages/shared/profiles/transformations/profileToRendererFormat.ts
+++ b/packages/shared/profiles/transformations/profileToRendererFormat.ts
@@ -61,6 +61,7 @@ export function defaultProfile({
 }): NewProfileForRenderer {
   const avatar = {
     userId,
+    ethAddress: userId,
     name,
     avatar: {
       snapshots: prepareSnapshots({ face256, body: '' }),

--- a/packages/shared/profiles/transformations/profileToRendererFormat.ts
+++ b/packages/shared/profiles/transformations/profileToRendererFormat.ts
@@ -51,13 +51,11 @@ export function profileToRendererFormat(
 export function defaultProfile({
   userId,
   name,
-  face256,
-  baseUrl
+  face256
 }: {
   userId: string
   name: string
   face256: string
-  baseUrl: string
 }): NewProfileForRenderer {
   const avatar = {
     userId,
@@ -68,7 +66,7 @@ export function defaultProfile({
       ...defaultAvatar()
     }
   }
-  return profileToRendererFormat(avatar, { baseUrl })
+  return profileToRendererFormat(avatar, { baseUrl: '' })
 }
 
 function defaultAvatar(): Omit<AvatarInfo, 'snapshots'> {

--- a/packages/shared/profiles/transformations/profileToRendererFormat.ts
+++ b/packages/shared/profiles/transformations/profileToRendererFormat.ts
@@ -1,11 +1,12 @@
 import { ParcelsWithAccess } from '@dcl/legacy-ecs/dist/decentraland/Types'
 import { convertToRGBObject } from './convertToRGBObject'
 import { isURL } from 'atomicHelpers/isURL'
-import { Avatar, IPFSv2, Snapshots } from '@dcl/schemas'
+import { Avatar, AvatarInfo, IPFSv2, Snapshots } from '@dcl/schemas'
 import { backupProfile } from '../generateRandomUserProfile'
 import { genericAvatarSnapshots } from 'config'
 import { calculateDisplayName } from './processServerProfile'
 import { NewProfileForRenderer } from './types'
+import { Color3 } from 'decentraland-ecs'
 
 export function profileToRendererFormat(
   profile: Partial<Avatar>,
@@ -41,21 +42,57 @@ export function profileToRendererFormat(
     tutorialFlagsMask: 0,
     tutorialStep: stage.tutorialStep || 0,
     snapshots: prepareSnapshots(profile.avatar!.snapshots),
-    avatar: {
-      wearables: profile.avatar?.wearables || [],
-      emotes: profile.avatar?.emotes || [],
-      bodyShape: profile.avatar?.bodyShape || '',
-      eyeColor: convertToRGBObject(profile.avatar?.eyes.color),
-      hairColor: convertToRGBObject(profile.avatar?.hair.color),
-      skinColor: convertToRGBObject(profile.avatar?.skin.color)
-    },
+    avatar: prepareAvatar(profile.avatar),
     baseUrl: options.baseUrl,
     parcelsWithAccess: options.parcels || []
   }
 }
 
+export function defaultProfile({
+  userId,
+  name,
+  face256,
+  baseUrl
+}: {
+  userId: string
+  name: string
+  face256: string
+  baseUrl: string
+}): NewProfileForRenderer {
+  const avatar = {
+    userId,
+    name,
+    avatar: {
+      snapshots: prepareSnapshots({ face256, body: '' }),
+      ...defaultAvatar()
+    }
+  }
+  return profileToRendererFormat(avatar, { baseUrl })
+}
+
+function defaultAvatar(): Omit<AvatarInfo, 'snapshots'> {
+  return {
+    bodyShape: '',
+    eyes: { color: Color3.White() },
+    hair: { color: Color3.White() },
+    skin: { color: Color3.White() },
+    wearables: []
+  }
+}
+
+function prepareAvatar(avatar?: Partial<AvatarInfo>) {
+  return {
+    wearables: avatar?.wearables || [],
+    emotes: avatar?.emotes || [],
+    bodyShape: avatar?.bodyShape || '',
+    eyeColor: convertToRGBObject(avatar?.eyes?.color),
+    hairColor: convertToRGBObject(avatar?.hair?.color),
+    skinColor: convertToRGBObject(avatar?.skin?.color)
+  }
+}
+
 // Ensure all snapshots are URLs
-function prepareSnapshots({ face256, body }: Snapshots): NewProfileForRenderer['snapshots'] {
+export function prepareSnapshots({ face256, body }: Snapshots): NewProfileForRenderer['snapshots'] {
   // TODO: move this logic to unity-renderer
   function prepare(value: string) {
     if (value === null || value === undefined) {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -524,6 +524,7 @@ export type ChatMessage = {
   messageId: string
   messageType: ChatMessageType
   sender?: string | undefined
+  senderName?: string | undefined
   recipient?: string | undefined
   timestamp: number
   body: string
@@ -832,6 +833,7 @@ export type GetChannelMembersPayload = {
 
 export type ChannelMember = {
   userId: string
+  name: string
   isOnline: boolean
 }
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -834,12 +834,7 @@ export type GetChannelMembersPayload = {
 export type ChannelMember = {
   userId: string
   name: string
-  isOnline: boolean
-}
-
-export type ChannelMemberProfile = {
-  userId: string
-  name: string
+  isOnline?: boolean
 }
 
 export type UpdateChannelMembersPayload = {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -837,6 +837,11 @@ export type ChannelMember = {
   isOnline: boolean
 }
 
+export type ChannelMemberProfile = {
+  userId: string
+  name: string
+}
+
 export type UpdateChannelMembersPayload = {
   channelId: string
   members: ChannelMember[]

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -841,3 +841,9 @@ export type UpdateChannelMembersPayload = {
   channelId: string
   members: ChannelMember[]
 }
+
+// Users allowed to create channels
+export type UsersAllowed = {
+  mode: number
+  allowList: string[]
+}

--- a/test/unit/channels.saga.test.ts
+++ b/test/unit/channels.saga.test.ts
@@ -129,6 +129,7 @@ const stubClient = (start: number, end: number, index: number) =>
   ({
     getCursorOnMessage: () => Promise.resolve({ getMessages: () => channelMessages.slice(start, end) }),
     searchChannel: () => Promise.resolve(publicRooms[index]),
+    getMemberInfo: () => ({displayName: undefined, avatarUrl: undefined}),
     getUserId: () => '0xa1'
   } as unknown as SocialAPI)
 
@@ -289,7 +290,7 @@ describe('Friends sagas - Channels Feature', () => {
     })
 
     afterEach(() => {
-      opts.end = opts.start - 2
+      opts.start = opts.start - 2
       sinon.restore()
       sinon.reset()
     })
@@ -312,6 +313,7 @@ describe('Friends sagas - Channels Feature', () => {
             timestamp: message.timestamp,
             body: message.text,
             sender: getUserIdFromMatrix(message.sender),
+            senderName: undefined,
             recipient: request.channelId
           }))
         }
@@ -325,19 +327,20 @@ describe('Friends sagas - Channels Feature', () => {
         const request: GetChannelMessagesPayload = {
           channelId: '000',
           limit: 2,
-          from: '2'
+          from: '3'
         }
 
-        const channelMessagesFiltered = channelMessages.slice(opts.start, opts.end)
+        const channelMessagesFiltered = channelMessages.slice(opts.start, 2)
 
         // parse messages
         const addChatMessagesPayload: AddChatMessagesPayload = {
           messages: channelMessagesFiltered.map((message) => ({
             messageId: message.id,
-            messageType: ChatMessageType.PRIVATE,
+            messageType: ChatMessageType.PUBLIC,
             timestamp: message.timestamp,
             body: message.text,
             sender: getUserIdFromMatrix(message.sender),
+            senderName: undefined,
             recipient: request.channelId
           }))
         }


### PR DESCRIPTION
# What? <!-- what is this PR? -->
1. Sends partial profiles to the explorer side when retrieving channel messages or members that are not in the catalog.
Partial profiles mean default avatars with a display name and image-related data to show in the chat window.

2. Prevent the creation of a channel in case a user who does not have permission (`users_allowed_to_create_channels`) to create it executes the /join command.

# Why? <!-- Explain the reason -->
1. When opening a channel chat window or retrieving members, some of them are probably not in the catalog, and loading them there is very expensive and makes the experience to be bad. 

