### PR TITLE
refactor: change tests to use saga directly 

### DIFF
--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -856,7 +856,7 @@ function sendUpdateUserStatus(id: string, status: CurrentUserStatus) {
   getUnityInstance().UpdateUserPresence(updateMessage)
 }
 
-export function updateUserStatus(client: SocialAPI, ...socialIds: string[]) {
+function updateUserStatus(client: SocialAPI, ...socialIds: string[]) {
   const statuses = client.getUserStatuses(...socialIds)
   const lastStatuses = getLastStatusOfFriends(store.getState())
 
@@ -870,7 +870,7 @@ export function updateUserStatus(client: SocialAPI, ...socialIds: string[]) {
   })
 }
 
-function* initializeStatusUpdateInterval() {
+export function* initializeStatusUpdateInterval() {
   let lastStatus: UpdateUserStatus | undefined = undefined
 
   while (true) {

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -11,6 +11,7 @@ import {
 } from 'shared/types'
 import sinon from 'sinon'
 import * as friendsSagas from '../../packages/shared/friends/sagas'
+import { setMatrixClient } from 'shared/friends/actions'
 import * as friendsSelectors from 'shared/friends/selectors'
 import * as profilesSelectors from 'shared/profiles/selectors'
 import { ProfileUserInfo } from 'shared/profiles/types'
@@ -20,6 +21,9 @@ import { FriendRequest, FriendsState } from 'shared/friends/types'
 import { Conversation, ConversationType, CurrentUserStatus, MessageStatus, PresenceType, SocialAPI, TextMessage } from 'dcl-social-client'
 import { AddUserProfilesToCatalogPayload } from 'shared/profiles/transformations/types'
 import * as daoSelectors from 'shared/dao/selectors'
+import { expectSaga } from 'redux-saga-test-plan'
+import { select } from 'redux-saga/effects'
+import { getRealm } from 'shared/comms/selectors'
 
 function getMockedAvatar(userId: string, name: string): ProfileUserInfo {
   return {
@@ -76,7 +80,7 @@ const toFriendRequest: FriendRequest = {
 
 
 const lastStatusOfFriendsEntries = [[
-  '@0xa1:server', {
+  '@0xa1:decentraland.org', {
     realm: {
       layer: '',
       serverName: 'serverTest'
@@ -143,7 +147,8 @@ const stubClient = {
       }
     }
     return m
-  }
+  },
+  setStatus: () => Promise.resolve(),
 } as unknown as SocialAPI
 
 const FETCH_CONTENT_SERVER = 'base-url'
@@ -407,7 +412,7 @@ describe('Friends sagas', () => {
     })
   })
 
-  describe('update friends status', () => {
+  describe.only('update friends status', () => {
     beforeEach(() => {
       const { store } = buildStore()
       globalThis.globalStore = store
@@ -418,17 +423,22 @@ describe('Friends sagas', () => {
       sinon.reset()
     })
 
-    it('should send status when it\'s not stored in the redux state yet', () => {
+    it('should send status when it\'s not stored in the redux state yet', async () => {
       mockStoreCalls()
-      sinon.mock(getUnityInstance())
-        .expects('UpdateUserPresence')
+      const unityMock = sinon.mock(getUnityInstance())
+      unityMock.expects('UpdateUserPresence')
         .once()
         .withExactArgs({ userId: '0xa1', realm: lastStatusOfFriendsEntries[0][1].realm, position: lastStatusOfFriendsEntries[0][1].position, presence: PresenceStatus.ONLINE })
-      friendsSagas.updateUserStatus(stubClient, '@0xa1:server')
-      sinon.mock(getUnityInstance()).verify()
+      await expectSaga(friendsSagas.initializeStatusUpdateInterval)
+      .provide([
+        [select(getRealm), { serverName: 'realm-test', hostname: 'localhost', protocol: 'http' }]
+      ])
+      .dispatch(setMatrixClient(stubClient))
+      .run()
+      unityMock.verify()
     })
 
-    it('should send status when it\'s stored but the new one is different', () => {
+    it('should send status when it\'s stored but the new one is different', async () => {
       mockStoreCalls(undefined, lastStatusOfFriends)
       const client: SocialAPI = {
         ...stubClient,
@@ -443,20 +453,33 @@ describe('Friends sagas', () => {
           return m
         }
       }
-      sinon.mock(getUnityInstance())
-        .expects('UpdateUserPresence')
+      const unityMock = sinon.mock(getUnityInstance())
+      unityMock.expects('UpdateUserPresence')
         .once()
         .withExactArgs({ userId: '0xa1', realm: lastStatusOfFriendsEntries[0][1].realm, position: {x: 100, y: 200}, presence: PresenceStatus.ONLINE })
-      friendsSagas.updateUserStatus(client, '@0xa1:server')
-      sinon.mock(getUnityInstance()).verify()
+      await expectSaga(friendsSagas.initializeStatusUpdateInterval)
+      .provide([
+        [select(friendsSelectors.getSocialClient), client], // override the stubClient mocked by mockStoreCalls(). need this to tweak getUserStatuses client function
+        [select(getRealm), { serverName: 'realm-test', hostname: 'localhost', protocol: 'http' }],
+      ])
+      .dispatch(setMatrixClient(client))
+      .run()
+      unityMock.verify()
     })
 
-    it('should not send status when it\'s equal to the last sent', () => {
+    it('should not send status when it\'s equal to the last sent', async () => {
       mockStoreCalls(undefined, lastStatusOfFriends)
-      sinon.mock(getUnityInstance()).expects('UpdateUserPresence').notCalled
-      friendsSagas.updateUserStatus(stubClient, '@0xa1:server')
-      sinon.mock(getUnityInstance()).verify()
+      const unityMock = sinon.mock(getUnityInstance());
+      unityMock.expects('UpdateUserPresence').never()
+      await expectSaga(friendsSagas.initializeStatusUpdateInterval)
+      .provide([
+        [select(getRealm), { serverName: 'realm-test', hostname: 'localhost', protocol: 'http' }]
+      ])
+      .dispatch(setMatrixClient(stubClient))
+      .run()
+      unityMock.verify()
     })
   })
 
 })
+ 

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -412,7 +412,7 @@ describe('Friends sagas', () => {
     })
   })
 
-  describe.only('update friends status', () => {
+  describe('update friends status', () => {
     beforeEach(() => {
       const { store } = buildStore()
       globalThis.globalStore = store

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -412,7 +412,7 @@ describe('Friends sagas', () => {
     })
   })
 
-  describe('update friends status', () => {
+  describe.only('update friends status', () => {
     beforeEach(() => {
       const { store } = buildStore()
       globalThis.globalStore = store
@@ -434,7 +434,7 @@ describe('Friends sagas', () => {
         [select(getRealm), { serverName: 'realm-test', hostname: 'localhost', protocol: 'http' }]
       ])
       .dispatch(setMatrixClient(stubClient))
-      .run()
+      .silentRun() // due to initializeStatusUpdateInterval saga is a while(true) gen
       unityMock.verify()
     })
 
@@ -463,7 +463,7 @@ describe('Friends sagas', () => {
         [select(getRealm), { serverName: 'realm-test', hostname: 'localhost', protocol: 'http' }],
       ])
       .dispatch(setMatrixClient(client))
-      .run()
+      .silentRun()
       unityMock.verify()
     })
 
@@ -476,7 +476,7 @@ describe('Friends sagas', () => {
         [select(getRealm), { serverName: 'realm-test', hostname: 'localhost', protocol: 'http' }]
       ])
       .dispatch(setMatrixClient(stubClient))
-      .run()
+      .silentRun()
       unityMock.verify()
     })
   })


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
This PR refactors some friends' tests to use the saga directly and react to actions instead of exporting a single function to be unit tested. 

# Why? <!-- Explain the reason -->
Use redux-saga for tests
