### PR TITLE
fix: `AudioStream` not stopping in certain conditions

### DIFF
--- a/packages/unity-interface/audioStream.ts
+++ b/packages/unity-interface/audioStream.ts
@@ -9,7 +9,7 @@ teleportObservable.add(() => {
 })
 
 export async function setAudioStream(url: string, play: boolean, volume: number) {
-  const isSameSrc = audioStreamSource.src.length > 1 && url.includes(audioStreamSource.src)
+  const isSameSrc = audioStreamSource.src.length > 1 && encodeURI(url) === audioStreamSource.src
   const playSrc = play && (!isSameSrc || (isSameSrc && audioStreamSource.paused))
 
   audioStreamSource.volume = volume


### PR DESCRIPTION
`AudioStream` playback was not being stopped when url contain spaces
fixes https://github.com/decentraland/sdk/issues/428
