### PR TITLE
fix: prevent ipcRenderer error when running kernel within VSCode webview

### DIFF
--- a/static/preview.html
+++ b/static/preview.html
@@ -752,6 +752,11 @@
 
 
       function initDesktop() {
+        // When run within VSCode the isElectron check passes, but it fails here because window.electron does not exist there
+        if (!window.electron || !window.electron.ipcRenderer) {
+          return
+        }
+        
         const ipcRenderer = window.electron.ipcRenderer
 
         ipcRenderer.on('downloadState', (event, payload) => {


### PR DESCRIPTION
<img width="1512" alt="Screen Shot 2022-10-17 at 17 52 15" src="https://user-images.githubusercontent.com/2781777/196800304-1da9a8a1-476d-4a1c-841e-00fc56e03136.png">

This PR fixes the issue where we get an error when trying to run the `preview.html` within a VSCode webview because it is detecting (correctly) that it is Electron, but the `window.electron` property does not exist in the context of a VSCode webview.