### PR TITLE
fix: Get latest profile before deploying

### DIFF
--- a/packages/shared/profiles/sagas.ts
+++ b/packages/shared/profiles/sagas.ts
@@ -218,6 +218,7 @@ export async function profileServerRequest(userId: string, version?: number): Pr
   try {
     let url = `${bff.services.legacy.lambdasServer}/profiles?id=${userId}`
     if (version) url = url + `&version=${version}`
+    url = url + `&no-cache=${Math.random()}`
 
     const response = await fetch(url)
 

--- a/packages/shared/profiles/sagas.ts
+++ b/packages/shared/profiles/sagas.ts
@@ -23,7 +23,7 @@ import {
   ProfileSuccessAction,
   profileFailure
 } from './actions'
-import { getCurrentUserProfileDirty, getProfileFromStore } from './selectors'
+import { getProfileFromStore } from './selectors'
 import { buildServerMetadata, ensureAvatarCompatibilityFormat } from './transformations/profileToServerFormat'
 import { ContentFile, ProfileType, ProfileUserInfo, RemoteProfile, REMOTE_AVATAR_IS_INVALID } from './types'
 import { ExplorerIdentity } from 'shared/session/types'

--- a/packages/shared/profiles/selectors.ts
+++ b/packages/shared/profiles/selectors.ts
@@ -42,13 +42,6 @@ export const getCurrentUserProfile = (store: RootProfileState & RootSessionState
   return currentUserId ? getProfile(store, currentUserId) : null
 }
 
-export const getCurrentUserProfileDirty = (store: RootProfileState & RootSessionState): Avatar | null => {
-  const currentUserId = getCurrentUserId(store)
-  if (!currentUserId) return null
-  const [_status, data] = getProfileStatusAndData(store, currentUserId)
-  return data || null
-}
-
 export const getCurrentUserProfileStatusAndData = (
   store: RootProfileState & RootSessionState
 ): [ProfileStatus | undefined, Avatar | undefined] => {

--- a/packages/shared/session/sagas.ts
+++ b/packages/shared/session/sagas.ts
@@ -115,7 +115,7 @@ function* authenticate(action: AuthenticateAction) {
 
   yield put(changeLoginState(LoginState.WAITING_PROFILE))
 
-  // set the etherum network to start loading profiles
+  // set the Ethereum network to start loading profiles
   const net: ETHEREUM_NETWORK = yield call(getAppNetwork)
   yield put(selectNetwork(net))
   registerProviderNetChanges()


### PR DESCRIPTION
Changes, If not guest: 
- Get the current profile always from the content server
- Enforce getting the latest version of the current profile from the server before making a deploy