### PR TITLE
fix track event moveToparcel

### DIFF
--- a/packages/shared/scene-loader/sagas.ts
+++ b/packages/shared/scene-loader/sagas.ts
@@ -180,14 +180,16 @@ function* rendererPositionSettler() {
       getPositionSpawnPointAndScene
     )
 
-    // and then settle the position
-    if (!isSettled) {
-      // Then set the parcel position for the scene loader
-      receivePositionReport(spawnPointAndScene.spawnPoint.position)
+    if (!!spawnPointAndScene.sceneId) {
+      // and then settle the position
+      if (!isSettled) {
+        console.log('Move to parcel, Settled,', spawnPointAndScene, isSettled)
+        // Then set the parcel position for the scene loader
+        receivePositionReport(spawnPointAndScene.spawnPoint.position)
+      }
+      // then update the position in the engine
+      getUnityInstance().Teleport(spawnPointAndScene.spawnPoint)
     }
-    // then update the position in the engine
-    getUnityInstance().Teleport(spawnPointAndScene.spawnPoint)
-
     yield take([POSITION_SETTLED, POSITION_UNSETTLED])
   }
 }

--- a/packages/shared/scene-loader/sagas.ts
+++ b/packages/shared/scene-loader/sagas.ts
@@ -180,16 +180,12 @@ function* rendererPositionSettler() {
       getPositionSpawnPointAndScene
     )
 
-    if (!!spawnPointAndScene.sceneId) {
-      // and then settle the position
-      if (!isSettled) {
-        console.log('Move to parcel, Settled,', spawnPointAndScene, isSettled)
-        // Then set the parcel position for the scene loader
-        receivePositionReport(spawnPointAndScene.spawnPoint.position)
-      }
-      // then update the position in the engine
-      getUnityInstance().Teleport(spawnPointAndScene.spawnPoint)
+    if (!isSettled && !!spawnPointAndScene.sceneId) {
+      // Then set the parcel position for the scene loader
+      receivePositionReport(spawnPointAndScene.spawnPoint.position)
     }
+    // then update the position in the engine
+    getUnityInstance().Teleport(spawnPointAndScene.spawnPoint)
     yield take([POSITION_SETTLED, POSITION_UNSETTLED])
   }
 }


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Fix moveToParcel track event reporting 0,0 when you start
...

# Why? <!-- Explain the reason -->

Kernel is reporting that we started on Genesis Plaza, and then we teleport out into the tile we actually had in the url, messing with our metrics
...

![image](https://user-images.githubusercontent.com/16782417/199271943-b8268a3c-adb0-44e7-9736-0138ca5fce5b.png)

