### PR TITLE
feat: bump `dcl-social-client` to version `1.20.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "dcl-catalyst-client": "^13.0.7",
         "dcl-quests-client": "^2.10.0",
         "dcl-scene-writer": "^1.1.2",
-        "dcl-social-client": "^1.20.1",
+        "dcl-social-client": "^1.20.3",
         "decentraland-ecs": "^6.0.4",
         "decentraland-rpc": "^3.1.9",
         "devtools-protocol": "0.0.615714",
@@ -3516,9 +3516,9 @@
       }
     },
     "node_modules/dcl-social-client": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.20.1.tgz",
-      "integrity": "sha512-MLdpS8+pWPROGXfIQ7xu/91Pdke47HfmMe1uod8BNN8AuqZ7MdDrMVP3ksGSuBLf7NGwhiZ+Zz8BQCm5lcP9pQ==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.20.3.tgz",
+      "integrity": "sha512-PayuwK0Kw2Onin2wcv1DnPJGwAoC7XI54FiE1ss8h6gARSfANmV288YXyg3ubaFC/CsOHXusMCA4HAHt9QftGA==",
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
         "matrix-js-sdk": "^21.0.0"
@@ -14791,9 +14791,9 @@
       "requires": {}
     },
     "dcl-social-client": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.20.1.tgz",
-      "integrity": "sha512-MLdpS8+pWPROGXfIQ7xu/91Pdke47HfmMe1uod8BNN8AuqZ7MdDrMVP3ksGSuBLf7NGwhiZ+Zz8BQCm5lcP9pQ==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.20.3.tgz",
+      "integrity": "sha512-PayuwK0Kw2Onin2wcv1DnPJGwAoC7XI54FiE1ss8h6gARSfANmV288YXyg3ubaFC/CsOHXusMCA4HAHt9QftGA==",
       "requires": {
         "@dcl/crypto": "^3.0.1",
         "matrix-js-sdk": "^21.0.0"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "dcl-catalyst-client": "^13.0.7",
     "dcl-quests-client": "^2.10.0",
     "dcl-scene-writer": "^1.1.2",
-    "dcl-social-client": "^1.20.1",
+    "dcl-social-client": "^1.20.3",
     "decentraland-ecs": "^6.0.4",
     "decentraland-rpc": "^3.1.9",
     "devtools-protocol": "0.0.615714",

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -1426,7 +1426,7 @@ function* handleLeaveChannel(action: LeaveChannel) {
   }
 }
 
-// Join or create channel
+// Join or create channel via command
 function* handleJoinOrCreateChannel(action: JoinOrCreateChannel) {
   try {
     const client: SocialAPI | null = getSocialClient(store.getState())
@@ -1494,7 +1494,7 @@ function* handleJoinOrCreateChannel(action: JoinOrCreateChannel) {
   }
 }
 
-// Join channel
+// Join channel via UI
 export async function joinChannel(request: JoinOrCreateChannelPayload) {
   try {
     const client: SocialAPI | null = getSocialClient(store.getState())
@@ -1514,7 +1514,7 @@ export async function joinChannel(request: JoinOrCreateChannelPayload) {
   }
 }
 
-// Create channel
+// Create channel via UI
 export async function createChannel(request: CreateChannelPayload) {
   try {
     const channelId = request.channelId

--- a/packages/shared/friends/selectors.ts
+++ b/packages/shared/friends/selectors.ts
@@ -39,29 +39,6 @@ export const getConversations = (
 }
 
 /**
- * Get all current conversations with messages the user has including DMs, channels, etc
- * @return `conversation` & `unreadMessages` boolean that indicates whether the conversation has unread messages.
- */
-export const getAllConversationsWithMessages = (
-  store: RootFriendsState
-): Array<{ conversation: Conversation; unreadMessages: boolean }> => {
-  const client = getSocialClient(store)
-  if (!client) return []
-
-  const conversations = client.getAllCurrentConversations()
-
-  return conversations
-    .filter((conv) => conv.conversation.hasMessages)
-    .map((conv) => ({
-      ...conv,
-      conversation: {
-        ...conv.conversation,
-        userIds: conv.conversation.userIds?.map((userId) => getUserIdFromMatrix(userId))
-      }
-    }))
-}
-
-/**
  * Get all conversations `ConversationType.DIRECT` with friends the user has befriended
  * @return `conversation` & `unreadMessages` boolean that indicates whether the conversation has unread messages.
  */


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
We currently have concurrent update errors for different users when there are multiple rooms trying to set up `m.direct` on the initial sync.

So, to avoid the concurrent update error, we decided to set the user's `m.direct` events all at once with a single request, which allows us to lighten the number of updates and thus reduce the concurrent update error.
