### PR TITLE
feat: add the service used for the chat to error logs

### DIFF
--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -1330,8 +1330,8 @@ function toSocialData(socialIds: string[]) {
 }
 
 function logAndTrackError(message: string, e: any) {
-  const url = getSynapseUrl(store.getState())
-  const variant = new URL(url).host.startsWith('synapse.') ? `Synapse` : `Social Service`
+  const isSynapseEnabled = getFeatureFlagEnabled(store.getState(), 'use-synapse-server')
+  const variant = isSynapseEnabled ? `Synapse` : `Social Service`
   const msg = `Social: ${variant} - ${message}`
 
   logger.error(msg, e)

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -185,6 +185,8 @@ function* initializeFriendsSaga() {
 
       const shouldRetry = !isLoggedIn && !isGuest
 
+      throw new Error('try new error')
+
       if (shouldRetry) {
         try {
           logger.log('[Social client] Initializing')
@@ -1330,11 +1332,14 @@ function toSocialData(socialIds: string[]) {
 }
 
 function logAndTrackError(message: string, e: any) {
-  logger.error(message, e)
+  const url = getSynapseUrl(store.getState())
+  const variant = new URL(url).host.startsWith('synapse.') ? `Synapse` : `Social Service`
+  const msg = `Service: ${variant} - ${message}`
 
+  logger.error(msg, e)
   trackEvent('error', {
     context: 'kernel#saga',
-    message: message,
+    message: msg,
     stack: '' + e
   })
 }

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -1332,7 +1332,7 @@ function toSocialData(socialIds: string[]) {
 function logAndTrackError(message: string, e: any) {
   const isSynapseEnabled = getFeatureFlagEnabled(store.getState(), 'use-synapse-server')
   const variant = isSynapseEnabled ? `Synapse` : `Social Service`
-  const msg = `Social: ${variant} - ${message}`
+  const msg = `${variant} - ${message}`
 
   logger.error(msg, e)
   trackEvent('error', {

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -185,8 +185,6 @@ function* initializeFriendsSaga() {
 
       const shouldRetry = !isLoggedIn && !isGuest
 
-      throw new Error('try new error')
-
       if (shouldRetry) {
         try {
           logger.log('[Social client] Initializing')
@@ -1334,7 +1332,7 @@ function toSocialData(socialIds: string[]) {
 function logAndTrackError(message: string, e: any) {
   const url = getSynapseUrl(store.getState())
   const variant = new URL(url).host.startsWith('synapse.') ? `Synapse` : `Social Service`
-  const msg = `Service: ${variant} - ${message}`
+  const msg = `Social: ${variant} - ${message}`
 
   logger.error(msg, e)
   trackEvent('error', {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Add the service that is being used for the chat to the log message

# Why? <!-- Explain the reason -->
In order to know if the service that is failing

Closes #655 