### PR TITLE
feat: Teleport worlds commands

### DIFF
--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -270,7 +270,7 @@ function initChatCommands() {
   })
 
   addChatCommand('world', 'Goes to a world', (message) => {
-    const worldString = `${message.trim()}.dcl.eth`
+    const worldString = `${message.trim()}`
     const response = ''
 
     changeRealm(worldString).catch((e) => {

--- a/packages/shared/chat/sagas.ts
+++ b/packages/shared/chat/sagas.ts
@@ -209,13 +209,21 @@ function initChatCommands() {
 
     if (isValidPosition) {
       const { x, y } = coordinates
-      response = TeleportController.goTo(x, y).message
+      TeleportController.goTo(x, y).then(
+        ({ message }) => notifyStatusThroughChat(message),
+        () => {
+          // Do nothing. This is handled inside controller
+        }
+      )
     } else {
       if (message.trim().toLowerCase() === 'random') {
-        response = TeleportController.goToRandom().message
+        TeleportController.goToRandom().then(
+          ({ message }) => notifyStatusThroughChat(message),
+          () => {
+            // Do nothing. This is handled inside controller
+          }
+        )
       } else if (message.trim().toLowerCase() === 'magic' || message.trim().toLowerCase() === 'crowd') {
-        response = `Teleporting to a crowd of people in current realm...`
-
         TeleportController.goToCrowd().then(
           ({ message }) => notifyStatusThroughChat(message),
           () => {
@@ -223,8 +231,6 @@ function initChatCommands() {
           }
         )
       } else if (message.trim().toLowerCase() === 'home') {
-        response = `Teleporting to home`
-
         TeleportController.goToHome().then(
           ({ message }) => notifyStatusThroughChat(message),
           () => {
@@ -251,6 +257,24 @@ function initChatCommands() {
 
     changeRealm(realmString).catch((e) => {
       notifyStatusThroughChat('changerealm: Could not join realm.')
+      defaultLogger.error(e)
+    })
+
+    return {
+      messageId: uuid(),
+      messageType: ChatMessageType.SYSTEM,
+      sender: 'Decentraland',
+      timestamp: Date.now(),
+      body: response
+    }
+  })
+
+  addChatCommand('world', 'Goes to a world', (message) => {
+    const worldString = `${message.trim()}.dcl.eth`
+    const response = ''
+
+    changeRealm(worldString).catch((e) => {
+      notifyStatusThroughChat('World does not exist.')
       defaultLogger.error(e)
     })
 

--- a/packages/shared/dao/index.ts
+++ b/packages/shared/dao/index.ts
@@ -257,10 +257,10 @@ export async function changeToMostPopulatedRealm(): Promise<void> {
   }
 
   const sortedArray: Candidate[] = allCandidates.sort((n1, n2) => {
-    if (n1.usersCount > n2.usersCount) {
+    if (n1.usersCount < n2.usersCount) {
       return 1
     }
-    if (n1.usersCount < n2.usersCount) {
+    if (n1.usersCount > n2.usersCount) {
       return -1
     }
     return 0

--- a/packages/shared/world/TeleportController.ts
+++ b/packages/shared/world/TeleportController.ts
@@ -60,7 +60,7 @@ export class TeleportController {
     }
   }
 
-  public static goToRandom(): { message: string; success: boolean } {
+  public static async goToRandom(): Promise<{ message: string; success: boolean }> {
     const x = Math.floor(Math.random() * 301) - 150
     const y = Math.floor(Math.random() * 301) - 150
     const tpMessage = `Teleporting to random location (${x}, ${y})...`
@@ -69,7 +69,6 @@ export class TeleportController {
 
   public static async goToHome(): Promise<{ message: string; success: boolean }> {
     try {
-      await changeToMostPopulatedRealm()
       const homeCoordinates = await fetchHomePoint()
 
       return TeleportController.goTo(
@@ -86,9 +85,15 @@ export class TeleportController {
     }
   }
 
-  public static goTo(x: number, y: number, teleportMessage?: string): { message: string; success: boolean } {
+  public static async goTo(
+    x: number,
+    y: number,
+    teleportMessage?: string
+  ): Promise<{ message: string; success: boolean }> {
     const tpMessage: string = teleportMessage ? teleportMessage : `Teleporting to ${x}, ${y}...`
     if (isInsideWorldLimits(x, y)) {
+      await changeToMostPopulatedRealm()
+
       store.dispatch(trackTeleportTriggered(tpMessage))
       /// This doesn't work when the logic of activate/deactivate rendering is so tightly coupled with the loading
       /// screen. The code needs rework

--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -391,7 +391,10 @@ export class BrowserInterface {
 
   public GoTo(data: { x: number; y: number }) {
     notifyStatusThroughChat(`Jumped to ${data.x},${data.y}!`)
-    TeleportController.goTo(data.x, data.y)
+    TeleportController.goTo(data.x, data.y).then(
+      () => {},
+      () => {}
+    )
   }
 
   public GoToMagic() {
@@ -862,10 +865,13 @@ export class BrowserInterface {
 
     changeRealm(serverName).then(
       () => {
-        const successMessage = `Jumped to ${x},${y} in realm ${serverName}!`
+        const successMessage = `Welcome to realm ${serverName}!`
         notifyStatusThroughChat(successMessage)
         getUnityInstance().ConnectionToRealmSuccess(data)
-        TeleportController.goTo(x, y, successMessage)
+        TeleportController.goTo(x, y, successMessage).then(
+          () => {},
+          () => {}
+        )
       },
       (e) => {
         const cause = e === 'realm-full' ? ' The requested realm is full.' : ''


### PR DESCRIPTION
Adds features required in [#3547](https://app.zenhub.com/workspaces/explorer-6047bad476c3c0001942ee91/issues/decentraland/unity-renderer/3547)

# What? <!-- what is this PR? -->

Adds a realm check before any goTo command to go back to a DAO realms if necessary
Adds a `/world name` command to go directly to a world. No ENS required
Function `GoToMostPopulatedRealm()` was returning the least populated realm. Changed it back

# Why? <!-- Explain the reason -->
