### PR TITLE
refactor: update scene-runtime and remove `useBinaryTransform`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@dcl/legacy-ecs": "^6.11.8",
         "@dcl/protocol": "^1.0.0-3587979266.commit-9fcad98",
         "@dcl/rpc": "^1.1.1",
-        "@dcl/scene-runtime": "^7.0.2",
+        "@dcl/scene-runtime": "^7.0.3-20221212182145.commit-ebd4eeb",
         "@dcl/schemas": "^5.29.0",
         "@dcl/urn-resolver": "^2.0.3",
         "@redux-saga/simple-saga-monitor": "^1.1.3",
@@ -295,9 +295,9 @@
       }
     },
     "node_modules/@dcl/scene-runtime": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/scene-runtime/-/scene-runtime-7.0.2.tgz",
-      "integrity": "sha512-u0XfO3RmMq/NyopvF6tTU7Y3qYp7n8oNnnM4h+Oi7w33AvNgQr0M1Ymdyo65XKBf7Us6Vum80U5WHVUjvTr5RQ==",
+      "version": "7.0.3-20221212182145.commit-ebd4eeb",
+      "resolved": "https://registry.npmjs.org/@dcl/scene-runtime/-/scene-runtime-7.0.3-20221212182145.commit-ebd4eeb.tgz",
+      "integrity": "sha512-FZmxX3Rv4572I/K7BqMxqwhD/4fxtDEgGKjhIlIq/+nM5WW/5LtRIzVDPjuyq4cpWmAmtv6lZcEcYlTMF6ghhQ==",
       "dependencies": {
         "@types/ws": "^8.5.3",
         "fp-future": "^1.0.1",
@@ -8328,9 +8328,9 @@
       }
     },
     "@dcl/scene-runtime": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/scene-runtime/-/scene-runtime-7.0.2.tgz",
-      "integrity": "sha512-u0XfO3RmMq/NyopvF6tTU7Y3qYp7n8oNnnM4h+Oi7w33AvNgQr0M1Ymdyo65XKBf7Us6Vum80U5WHVUjvTr5RQ==",
+      "version": "7.0.3-20221212182145.commit-ebd4eeb",
+      "resolved": "https://registry.npmjs.org/@dcl/scene-runtime/-/scene-runtime-7.0.3-20221212182145.commit-ebd4eeb.tgz",
+      "integrity": "sha512-FZmxX3Rv4572I/K7BqMxqwhD/4fxtDEgGKjhIlIq/+nM5WW/5LtRIzVDPjuyq4cpWmAmtv6lZcEcYlTMF6ghhQ==",
       "requires": {
         "@types/ws": "^8.5.3",
         "fp-future": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@dcl/legacy-ecs": "^6.11.8",
     "@dcl/protocol": "^1.0.0-3587979266.commit-9fcad98",
     "@dcl/rpc": "^1.1.1",
-    "@dcl/scene-runtime": "^7.0.2",
+    "@dcl/scene-runtime": "^7.0.3-20221212182145.commit-ebd4eeb",
     "@dcl/schemas": "^5.29.0",
     "@dcl/urn-resolver": "^2.0.3",
     "@redux-saga/simple-saga-monitor": "^1.1.3",

--- a/packages/shared/apis/host/EnvironmentAPI.ts
+++ b/packages/shared/apis/host/EnvironmentAPI.ts
@@ -18,7 +18,6 @@ import {
 } from '@dcl/protocol/out-ts/decentraland/kernel/apis/environment_api.gen'
 import { EnvironmentRealm, Platform } from './../IEnvironmentAPI'
 import { PortContextService } from './context'
-import { transformSerializeOpt } from 'unity-interface/transformSerializationOpt'
 import { IRealmAdapter } from 'shared/realm/types'
 import { realmToConnectionString, urlWithProtocol } from 'shared/realm/resolver'
 

--- a/packages/shared/apis/host/EnvironmentAPI.ts
+++ b/packages/shared/apis/host/EnvironmentAPI.ts
@@ -64,8 +64,7 @@ export function registerEnvironmentApiServiceServerImplementation(
       return {
         clientUri: location.href,
         configurations: {
-          questsServerUrl: getServerConfigurations(getSelectedNetwork(store.getState())).questsUrl,
-          enableBinaryTransform: `${transformSerializeOpt.useBinaryTransform}`
+          questsServerUrl: getServerConfigurations(getSelectedNetwork(store.getState())).questsUrl
         }
       }
     },

--- a/packages/unity-interface/BrowserInterface.ts
+++ b/packages/unity-interface/BrowserInterface.ts
@@ -81,7 +81,6 @@ import { Authenticator } from '@dcl/crypto'
 import { denyPortableExperiences, removeScenePortableExperience } from 'shared/portableExperiences/actions'
 import { setDecentralandTime } from 'shared/apis/host/EnvironmentAPI'
 import { Avatar, generateLazyValidator, JSONSchema } from '@dcl/schemas'
-import { transformSerializeOpt } from 'unity-interface/transformSerializationOpt'
 import {
   getFriendRequests,
   getFriends,
@@ -329,8 +328,6 @@ export class BrowserInterface {
   // TODO: remove useBinaryTransform after SDK7 is fully in prod
   public SystemInfoReport(data: SystemInfoPayload & { useBinaryTransform?: boolean }) {
     trackEvent('system info report', data)
-
-    transformSerializeOpt.useBinaryTransform = !!data.useBinaryTransform
 
     this.startedFuture.resolve()
   }

--- a/packages/unity-interface/transformSerializationOpt.ts
+++ b/packages/unity-interface/transformSerializationOpt.ts
@@ -1,4 +1,0 @@
-// TODO: remove useBinaryTransform after SDK7 is fully in prod
-export const transformSerializeOpt = {
-  useBinaryTransform: true
-}


### PR DESCRIPTION

# What? <!-- what is this PR? -->
Remove `useBinaryTrasnform`

# Why? <!-- Explain the reason -->
No longer needed, breaks compatibility with very old renderers (+3 months)
