### PR TITLE
chore: bump `@dcl/protocol` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@dcl/hashing": "^1.1.2",
         "@dcl/kernel-interface": "^2.0.0-20210922153939.commit-017905d",
         "@dcl/legacy-ecs": "^6.11.8",
-        "@dcl/protocol": "^1.0.0-3587979266.commit-9fcad98",
+        "@dcl/protocol": "^1.0.0-3695908652.commit-2552b6c",
         "@dcl/rpc": "^1.1.1",
         "@dcl/scene-runtime": "^7.0.3-20221212182145.commit-ebd4eeb",
         "@dcl/schemas": "^5.29.0",
@@ -278,9 +278,9 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-3587979266.commit-9fcad98",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3587979266.commit-9fcad98.tgz",
-      "integrity": "sha512-Xjp2WJfMOm3rA+RjWF4jMN+R+pAgykI1R9LbNtEL92z++mmC/Qm8CvoGWAT/e3/fpZF3UsHjkcyf1Eochhjcdg==",
+      "version": "1.0.0-3695908652.commit-2552b6c",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3695908652.commit-2552b6c.tgz",
+      "integrity": "sha512-9VT04QCreY2XBJrz/JqqhwoNB34xIbeKxKQpicxOP7gyBIuTbH2uaGNJcbpYwBr51aZ54Jn8K83dtK4pJs0+JQ==",
       "dependencies": {
         "ts-proto": "^1.126.1"
       }
@@ -8311,9 +8311,9 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "@dcl/protocol": {
-      "version": "1.0.0-3587979266.commit-9fcad98",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3587979266.commit-9fcad98.tgz",
-      "integrity": "sha512-Xjp2WJfMOm3rA+RjWF4jMN+R+pAgykI1R9LbNtEL92z++mmC/Qm8CvoGWAT/e3/fpZF3UsHjkcyf1Eochhjcdg==",
+      "version": "1.0.0-3695908652.commit-2552b6c",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3695908652.commit-2552b6c.tgz",
+      "integrity": "sha512-9VT04QCreY2XBJrz/JqqhwoNB34xIbeKxKQpicxOP7gyBIuTbH2uaGNJcbpYwBr51aZ54Jn8K83dtK4pJs0+JQ==",
       "requires": {
         "ts-proto": "^1.126.1"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@dcl/hashing": "^1.1.2",
     "@dcl/kernel-interface": "^2.0.0-20210922153939.commit-017905d",
     "@dcl/legacy-ecs": "^6.11.8",
-    "@dcl/protocol": "^1.0.0-3587979266.commit-9fcad98",
+    "@dcl/protocol": "^1.0.0-3695908652.commit-2552b6c",
     "@dcl/rpc": "^1.1.1",
     "@dcl/scene-runtime": "^7.0.3-20221212182145.commit-ebd4eeb",
     "@dcl/schemas": "^5.29.0",


### PR DESCRIPTION
Bump protocol version to include the necessary definitions for the implementation of the New Friend Request. Find specs [here](https://github.com/decentraland/protocol/pull/87)