### PR TITLE
Add Lambda 2 Public Url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@dcl/hashing": "^1.1.2",
         "@dcl/kernel-interface": "^2.0.0-20210922153939.commit-017905d",
         "@dcl/legacy-ecs": "^6.11.8",
-        "@dcl/protocol": "^1.0.0-3766287015.commit-7d88411",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3793446104.commit-ef6bc17.tgz",
         "@dcl/rpc": "^1.1.1",
         "@dcl/scene-runtime": "^7.0.3-20221223152034.commit-23102ad",
         "@dcl/schemas": "^5.29.0",
@@ -278,9 +278,10 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-3766287015.commit-7d88411",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3766287015.commit-7d88411.tgz",
-      "integrity": "sha512-KY3AeHcqzPDoThYA6nggCyQLVSdGP/97yvtUi+dlg+bHVMrLbYPjFLpRQZ+1mAl446aE5jvq1HYpyAh8eckP1w==",
+      "version": "1.0.0-3793446104.commit-ef6bc17",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3793446104.commit-ef6bc17.tgz",
+      "integrity": "sha512-sYFShLZPqKio6TM8Ndr70dZmS2s7CfF5gnFT8ffG0VYrvRgeJPAhUA34aP+CMsUFrpvpwjq/TWXdXSNOw/g6Wg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ts-proto": "^1.126.1"
       }
@@ -8311,9 +8312,8 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "@dcl/protocol": {
-      "version": "1.0.0-3766287015.commit-7d88411",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3766287015.commit-7d88411.tgz",
-      "integrity": "sha512-KY3AeHcqzPDoThYA6nggCyQLVSdGP/97yvtUi+dlg+bHVMrLbYPjFLpRQZ+1mAl446aE5jvq1HYpyAh8eckP1w==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3793446104.commit-ef6bc17.tgz",
+      "integrity": "sha512-sYFShLZPqKio6TM8Ndr70dZmS2s7CfF5gnFT8ffG0VYrvRgeJPAhUA34aP+CMsUFrpvpwjq/TWXdXSNOw/g6Wg==",
       "requires": {
         "ts-proto": "^1.126.1"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@dcl/hashing": "^1.1.2",
     "@dcl/kernel-interface": "^2.0.0-20210922153939.commit-017905d",
     "@dcl/legacy-ecs": "^6.11.8",
-    "@dcl/protocol": "^1.0.0-3766287015.commit-7d88411",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3793446104.commit-ef6bc17.tgz",
     "@dcl/rpc": "^1.1.1",
     "@dcl/scene-runtime": "^7.0.3-20221223152034.commit-23102ad",
     "@dcl/schemas": "^5.29.0",

--- a/packages/shared/dao/index.ts
+++ b/packages/shared/dao/index.ts
@@ -185,7 +185,8 @@ async function resolveOfflineRealmAboutFromConnectionString(
         healthy: true,
         lambdas: {
           healthy: true,
-          publicUrl: `${baseUrl}lambdas`
+          publicUrl: `${baseUrl}lambdas`,
+          publicUrl2: `${baseUrl}lamb2`
         },
         acceptingUsers: true
       },

--- a/packages/shared/realm/resolver.ts
+++ b/packages/shared/realm/resolver.ts
@@ -31,6 +31,7 @@ export async function adapterForRealmConfig(
   about.lambdas = {
     healthy: false,
     publicUrl: baseUrl + '/lambdas',
+    publicUrl2: baseUrl + '/lamb2',
     ...about.lambdas
   }
   about.configurations = {

--- a/test/sceneEvents/comms.spec.ts
+++ b/test/sceneEvents/comms.spec.ts
@@ -36,7 +36,8 @@ const about: AboutResponse = {
   healthy: true,
   lambdas: {
     healthy: false,
-    publicUrl: 'https://lambdas'
+    publicUrl: 'https://lambdas',
+    publicUrl2: 'https://lamb2'
   },
   acceptingUsers: true
 }

--- a/test/unit/comms-resolver.test.tsx
+++ b/test/unit/comms-resolver.test.tsx
@@ -124,7 +124,7 @@ describe('Comms resolver', () => {
         lambdas: {
           healthy: true,
           publicUrl: 'http://peer.decentraland.zone/lambdas',
-          publicUrl2: 'https://peer.decentraland.zone/lamb2'
+          publicUrl2: 'http://peer.decentraland.zone/lamb2'
         },
         acceptingUsers: true
       },

--- a/test/unit/comms-resolver.test.tsx
+++ b/test/unit/comms-resolver.test.tsx
@@ -35,7 +35,8 @@ describe('Comms resolver', () => {
         healthy: true,
         lambdas: {
           healthy: true,
-          publicUrl: 'https://peer.decentraland.org/lambdas'
+          publicUrl: 'https://peer.decentraland.org/lambdas',
+          publicUrl2: 'https://peer.decentraland.org/lamb2'
         },
         acceptingUsers: true
       },
@@ -64,7 +65,8 @@ describe('Comms resolver', () => {
         healthy: true,
         lambdas: {
           healthy: true,
-          publicUrl: 'https://peer.decentraland.zone/lambdas'
+          publicUrl: 'https://peer.decentraland.zone/lambdas',
+          publicUrl2: 'https://peer.decentraland.org/lamb2'
         },
         acceptingUsers: true
       },
@@ -92,7 +94,8 @@ describe('Comms resolver', () => {
         healthy: true,
         lambdas: {
           healthy: true,
-          publicUrl: 'https://peer.decentraland.zone/lambdas'
+          publicUrl: 'https://peer.decentraland.zone/lambdas',
+          publicUrl2: 'https://peer.decentraland.org/lamb2'
         },
         acceptingUsers: true
       },
@@ -120,7 +123,8 @@ describe('Comms resolver', () => {
         healthy: true,
         lambdas: {
           healthy: true,
-          publicUrl: 'http://peer.decentraland.zone/lambdas'
+          publicUrl: 'http://peer.decentraland.zone/lambdas',
+          publicUrl2: 'https://peer.decentraland.org/lamb2'
         },
         acceptingUsers: true
       },

--- a/test/unit/comms-resolver.test.tsx
+++ b/test/unit/comms-resolver.test.tsx
@@ -66,7 +66,7 @@ describe('Comms resolver', () => {
         lambdas: {
           healthy: true,
           publicUrl: 'https://peer.decentraland.zone/lambdas',
-          publicUrl2: 'https://peer.decentraland.org/lamb2'
+          publicUrl2: 'https://peer.decentraland.zone/lamb2'
         },
         acceptingUsers: true
       },
@@ -95,7 +95,7 @@ describe('Comms resolver', () => {
         lambdas: {
           healthy: true,
           publicUrl: 'https://peer.decentraland.zone/lambdas',
-          publicUrl2: 'https://peer.decentraland.org/lamb2'
+          publicUrl2: 'https://peer.decentraland.zone/lamb2'
         },
         acceptingUsers: true
       },
@@ -124,7 +124,7 @@ describe('Comms resolver', () => {
         lambdas: {
           healthy: true,
           publicUrl: 'http://peer.decentraland.zone/lambdas',
-          publicUrl2: 'https://peer.decentraland.org/lamb2'
+          publicUrl2: 'https://peer.decentraland.zone/lamb2'
         },
         acceptingUsers: true
       },


### PR DESCRIPTION
Needed for unity-renderer/3834:
We are moving consuption of new Lambda endpoints to Renderer directly.

Once both PRs for Renderer and Kernel are approved I will move the tip of `protocol` to `dcl@next`