### PR TITLE
fix: add request dispatcher to friendRequestId

### DIFF
--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -576,7 +576,7 @@ function* refreshFriends() {
 
     const requestedFromIds = fromFriendRequests.map(
       (request): FriendRequest => ({
-        friendRequestId: encodeFriendRequestId(ownId, request.from),
+        friendRequestId: encodeFriendRequestId(ownId, request.from, true, FriendshipAction.REQUESTED_FROM),
         createdAt: request.createdAt,
         userId: getUserIdFromMatrix(request.from),
         message: request.message
@@ -584,7 +584,7 @@ function* refreshFriends() {
     )
     const requestedToIds = toFriendRequests.map(
       (request): FriendRequest => ({
-        friendRequestId: encodeFriendRequestId(ownId, request.to),
+        friendRequestId: encodeFriendRequestId(ownId, request.to, false, FriendshipAction.REQUESTED_TO),
         createdAt: request.createdAt,
         userId: getUserIdFromMatrix(request.to),
         message: request.message
@@ -1221,11 +1221,11 @@ function* handleUpdateFriendship({ payload, meta }: UpdateFriendship) {
       return
     }
 
-    const ownId = client.getUserId()
-    const friendRequestId = encodeFriendRequestId(ownId, userId)
-
     const incoming = meta.incoming
     const hasSentFriendshipRequest = state.toFriendRequests.some((request) => request.userId === userId)
+
+    const ownId = client.getUserId()
+    const friendRequestId = encodeFriendRequestId(ownId, userId, incoming, action)
 
     const friendRequestTypeSelector = hasSentFriendshipRequest ? 'toFriendRequests' : 'fromFriendRequests'
     const updateTotalFriendRequestsPayloadSelector: keyof UpdateTotalFriendRequestsPayload = hasSentFriendshipRequest
@@ -2206,7 +2206,7 @@ export async function requestFriendship(request: SendFriendRequestPayload) {
     if (!response.error) {
       const sendFriendRequest: SendFriendRequestReplyOk = {
         friendRequest: {
-          friendRequestId: encodeFriendRequestId(ownId, userId),
+          friendRequestId: encodeFriendRequestId(ownId, userId, false, FriendshipAction.REQUESTED_TO),
           timestamp: Date.now(),
           from: getUserIdFromMatrix(ownId),
           to: userId,

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -1338,7 +1338,10 @@ function* handleUpdateFriendship({ payload, meta }: UpdateFriendship) {
         if (!request) {
           newState = {
             ...state,
-            fromFriendRequests: [...state.fromFriendRequests, { createdAt: Date.now(), userId, friendRequestId }]
+            fromFriendRequests: [
+              ...state.fromFriendRequests,
+              { createdAt: Date.now(), userId, friendRequestId, message: messageBody }
+            ]
           }
         }
 
@@ -1372,7 +1375,10 @@ function* handleUpdateFriendship({ payload, meta }: UpdateFriendship) {
         if (!request) {
           newState = {
             ...state,
-            toFriendRequests: [...state.toFriendRequests, { createdAt: Date.now(), userId, friendRequestId }]
+            toFriendRequests: [
+              ...state.toFriendRequests,
+              { createdAt: Date.now(), userId, friendRequestId, message: messageBody }
+            ]
           }
         }
 

--- a/packages/shared/friends/utils.ts
+++ b/packages/shared/friends/utils.ts
@@ -92,7 +92,7 @@ export function isNewFriendRequestEnabled(): boolean {
  * @param ownId
  * @param otherUserId
  * @param incoming indicates whether the action was incoming (true) or outgoing (false)
- * @param action represents the action being taken on the friend
+ * @param action represents the action being taken
  */
 export function encodeFriendRequestId(ownId: string, otherUserId: string, incoming: boolean, action: FriendshipAction) {
   // We always want the friendRequestId to be formed with the pattern '0x1111ada11111'

--- a/packages/shared/friends/utils.ts
+++ b/packages/shared/friends/utils.ts
@@ -100,22 +100,36 @@ export function encodeFriendRequestId(ownId: string, otherUserId: string, incomi
   otherUserId = getUserIdFromMatrix(otherUserId)
 
   // Dispatcher is the last 4 characters of the user id of the user who initiated the friendship, that is, sent the friend request
-  let dispatcher = ownId.substring(ownId.length - 4)
+  let dispatcher = ''
 
   // If the friend request is incoming and the action is either CANCELED or REQUESTED_FROM,
   // set the dispatcher to the last 4 characters of the otherUserId
   if (incoming) {
     switch (action) {
-      case FriendshipAction.CANCELED || FriendshipAction.REQUESTED_FROM:
+      case FriendshipAction.CANCELED:
         dispatcher = otherUserId.substring(otherUserId.length - 4)
+        break
+      case FriendshipAction.REQUESTED_FROM:
+        dispatcher = otherUserId.substring(otherUserId.length - 4)
+        break
+      // Otherwise set the dispatcher to the last 4 characters of the ownId
+      default:
+        dispatcher = ownId.substring(ownId.length - 4)
         break
     }
     // If the friend request is outgoing and the action is either APPROVED or REJECTED,
     // set the dispatcher to the last 4 characters of the otherUserId
   } else {
     switch (action) {
-      case FriendshipAction.APPROVED || FriendshipAction.REJECTED:
+      case FriendshipAction.APPROVED:
         dispatcher = otherUserId.substring(otherUserId.length - 4)
+        break
+      case FriendshipAction.REJECTED:
+        dispatcher = otherUserId.substring(otherUserId.length - 4)
+        break
+      // Otherwise set the dispatcher to the last 4 characters of the ownId
+      default:
+        dispatcher = ownId.substring(ownId.length - 4)
         break
     }
   }

--- a/packages/shared/friends/utils.ts
+++ b/packages/shared/friends/utils.ts
@@ -88,7 +88,13 @@ export function isNewFriendRequestEnabled(): boolean {
 /**
  * Encode friendRequestId from the user IDs involved in the friendship event.
  * **It is important to send the ownId as the first parameter, otherwise it will cause bugs.**
- * The rule is: `ownId` < `otherUserId` ? `ownId_otherUserId_dispatcher` : `otherUserId_ownId_dispatcher`
+ * The rule is: `ownId` < `otherUserId` ? `ownId_otherUserId_requester` : `otherUserId_ownId_requester`
+ *
+ * If the friend request is incoming and the action is either CANCELED or REQUESTED_FROM or
+ * if the friend request is outgoing and the action is either APPROVED or REJECTED,
+ * set the requester to the last 4 characters of the otherUserId.
+ * Otherwise set the requester to the last 4 characters of the ownId.
+ *
  * @param ownId
  * @param otherUserId
  * @param incoming indicates whether the action was incoming (true) or outgoing (false)
@@ -99,18 +105,13 @@ export function encodeFriendRequestId(ownId: string, otherUserId: string, incomi
   ownId = getUserIdFromMatrix(ownId)
   otherUserId = getUserIdFromMatrix(otherUserId)
 
-  // requester is the last 4 characters of the user id of the user who initiated the friendship, that is, sent the friend request
   let requester = ''
 
-  // If the friend request is incoming and the action is either CANCELED or REQUESTED_FROM,
-  // set the requester to the last 4 characters of the otherUserId. Otherwise set the requester to the last 4 characters of the ownId
   if (incoming) {
     requester =
       action === FriendshipAction.CANCELED || action === FriendshipAction.REQUESTED_FROM
         ? otherUserId.substring(otherUserId.length - 4)
         : ownId.substring(ownId.length - 4)
-    // If the friend request is outgoing and the action is either APPROVED or REJECTED,
-    // set the requester to the last 4 characters of the otherUserId. Otherwise set the requester to the last 4 characters of the ownId
   } else {
     requester =
       action === FriendshipAction.APPROVED || action === FriendshipAction.REJECTED

--- a/packages/shared/friends/utils.ts
+++ b/packages/shared/friends/utils.ts
@@ -99,42 +99,26 @@ export function encodeFriendRequestId(ownId: string, otherUserId: string, incomi
   ownId = getUserIdFromMatrix(ownId)
   otherUserId = getUserIdFromMatrix(otherUserId)
 
-  // Dispatcher is the last 4 characters of the user id of the user who initiated the friendship, that is, sent the friend request
-  let dispatcher = ''
+  // requester is the last 4 characters of the user id of the user who initiated the friendship, that is, sent the friend request
+  let requester = ''
 
   // If the friend request is incoming and the action is either CANCELED or REQUESTED_FROM,
-  // set the dispatcher to the last 4 characters of the otherUserId
+  // set the requester to the last 4 characters of the otherUserId. Otherwise set the requester to the last 4 characters of the ownId
   if (incoming) {
-    switch (action) {
-      case FriendshipAction.CANCELED:
-        dispatcher = otherUserId.substring(otherUserId.length - 4)
-        break
-      case FriendshipAction.REQUESTED_FROM:
-        dispatcher = otherUserId.substring(otherUserId.length - 4)
-        break
-      // Otherwise set the dispatcher to the last 4 characters of the ownId
-      default:
-        dispatcher = ownId.substring(ownId.length - 4)
-        break
-    }
+    requester =
+      action === FriendshipAction.CANCELED || action === FriendshipAction.REQUESTED_FROM
+        ? otherUserId.substring(otherUserId.length - 4)
+        : ownId.substring(ownId.length - 4)
     // If the friend request is outgoing and the action is either APPROVED or REJECTED,
-    // set the dispatcher to the last 4 characters of the otherUserId
+    // set the requester to the last 4 characters of the otherUserId. Otherwise set the requester to the last 4 characters of the ownId
   } else {
-    switch (action) {
-      case FriendshipAction.APPROVED:
-        dispatcher = otherUserId.substring(otherUserId.length - 4)
-        break
-      case FriendshipAction.REJECTED:
-        dispatcher = otherUserId.substring(otherUserId.length - 4)
-        break
-      // Otherwise set the dispatcher to the last 4 characters of the ownId
-      default:
-        dispatcher = ownId.substring(ownId.length - 4)
-        break
-    }
+    requester =
+      action === FriendshipAction.APPROVED || action === FriendshipAction.REJECTED
+        ? otherUserId.substring(otherUserId.length - 4)
+        : ownId.substring(ownId.length - 4)
   }
 
-  return ownId < otherUserId ? `${ownId}_${otherUserId}_${dispatcher}` : `${otherUserId}_${ownId}_${dispatcher}`
+  return ownId < otherUserId ? `${ownId}_${otherUserId}_${requester}` : `${otherUserId}_${ownId}_${requester}`
 }
 
 /**

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -7,7 +7,8 @@ import {
   GetFriendsPayload,
   GetFriendsWithDirectMessagesPayload,
   GetPrivateMessagesPayload,
-  PresenceStatus
+  PresenceStatus,
+  FriendshipAction
 } from 'shared/types'
 import sinon from 'sinon'
 import * as friendsSagas from '../../packages/shared/friends/sagas'
@@ -80,13 +81,13 @@ const textMessages: TextMessage[] = [
 const friendIds = ['0xa1', '0xb1', '0xc1', '0xd1']
 
 const fromFriendRequest: FriendRequest = {
-  friendRequestId: encodeFriendRequestId('ownId', '0xa1'),
+  friendRequestId: encodeFriendRequestId('ownId', '0xa1', true, FriendshipAction.REQUESTED_FROM),
   userId: '0xa1',
   createdAt: 123123132
 }
 
 const toFriendRequest: FriendRequest = {
-  friendRequestId: encodeFriendRequestId('ownId', '0xa1'),
+  friendRequestId: encodeFriendRequestId('ownId', '0xa1', false, FriendshipAction.REQUESTED_TO),
   userId: '0xa2',
   createdAt: 123123132
 }


### PR DESCRIPTION
For the new flow of Friend Request, we've added a field called `friendRequestId`, which is generated by kernel when a request is created. This field is used to manage the actions that can be executed on a friendship. Since Matrix doesn't provide a way to generate a `friendshipId`, we've decided to generate one by using the addresses of the users involved, with the rule and pattern `addressUser1` < `addressUser2` ?  `addressUser1_addressUser2` : `addressUser2_addressUser1`.

![image](https://user-images.githubusercontent.com/42394626/209867711-e1e5b966-a96f-42a3-8194-8c2301b442f6.png)

But there's a problem with that, because (see the [video](https://github.com/decentraland/unity-renderer/pull/3823#pullrequestreview-1230652236) to understand better) in that way, from renderer they cannot differentiate between friend requests and subsequent actions and they end up having different information for the same friendRequestId. They need to be able to differentiate between a request sent by User A to User B and a request sent by User B to User A.

**Note: we don't persist the friendRequestId. Therefore, it always needs to be derivable.**

**Solution I came up with:** 🫠
The rule is: `ownId` < `otherUserId` ? `ownId_otherUserId_requester` : `otherUserId_ownId_requester`

`requester` is the last 4 characters of the user id of the user who initiated the friendship, that is, sent the friend request. If the friend request is incoming and the action is either CANCELED or REQUESTED_FROM or if the friend request is outgoing and the action is either APPROVED or REJECTED, set the requester to the last 4 characters of the otherUserId. Otherwise set the requester to the last 4 characters of the ownId. In this way, we'll always be able to differentiate between a request sent by User A to User B and a request sent by User B to User A and the and subsequent actions that can be executed on a friendship.