### PR TITLE
feat: add feature flag to enable the web gif processor instead of the unity gif processor

### DIFF
--- a/packages/shared/meta/selectors.ts
+++ b/packages/shared/meta/selectors.ts
@@ -59,6 +59,9 @@ export const getDisabledCatalystConfig = (store: RootMetaState): string[] => {
 export const isLiveKitVoiceChatFeatureFlag = (store: RootMetaState): boolean =>
   getFeatureFlagEnabled(store, 'livekit-voicechat') as boolean
 
+// Enable the gif processor on the web instead of processing it in Unity (just for WebGL build)
+export const isGifWebSupported = (store: RootMetaState): boolean => getFeatureFlagEnabled(store, 'gif-web') as boolean
+
 export function getMaxVisiblePeers(store: RootMetaState): number {
   return (
     QS_MAX_VISIBLE_PEERS ||

--- a/packages/shared/meta/types.ts
+++ b/packages/shared/meta/types.ts
@@ -42,6 +42,7 @@ export type FeatureFlagsName =
   | 'web_cap_fps' // caps the web client FPS
   | 'disabled-catalyst'
   | 'livekit-voicechat'
+  | 'gif-web'
   | 'ping_enabled'
   | 'use-synapse-server'
   | 'new_tutorial'

--- a/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/packages/unity-interface/kernelConfigForRenderer.ts
@@ -1,5 +1,5 @@
 import { KernelConfigForRenderer } from 'shared/types'
-import { getAvatarTextureAPIBaseUrl, commConfigurations, WSS_ENABLED } from 'config'
+import { getAvatarTextureAPIBaseUrl, commConfigurations } from 'config'
 import { nameValidCharacterRegex, nameValidRegex } from 'shared/profiles/utils/names'
 import { getWorld } from '@dcl/schemas'
 import { injectVersions } from 'shared/rolloutVersions'
@@ -27,10 +27,7 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
       nameValidRegex: nameValidRegex.toString().replace(/[/]/g, '')
     },
     debugConfig: undefined,
-    gifSupported:
-      typeof (window as any).OffscreenCanvas !== 'undefined' &&
-      typeof (window as any).OffscreenCanvasRenderingContext2D === 'function' &&
-      !WSS_ENABLED,
+    gifSupported: false,
     network,
     validWorldRanges: getWorld().validWorldRanges,
     kernelVersion: versions['@dcl/kernel'] || 'unknown-kernel-version',

--- a/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/packages/unity-interface/kernelConfigForRenderer.ts
@@ -1,10 +1,11 @@
 import { KernelConfigForRenderer } from 'shared/types'
-import { getAvatarTextureAPIBaseUrl, commConfigurations } from 'config'
+import { getAvatarTextureAPIBaseUrl, commConfigurations, WSS_ENABLED } from 'config'
 import { nameValidCharacterRegex, nameValidRegex } from 'shared/profiles/utils/names'
 import { getWorld } from '@dcl/schemas'
 import { injectVersions } from 'shared/rolloutVersions'
 import { store } from 'shared/store/isolatedStore'
 import { getSelectedNetwork } from 'shared/dao/selectors'
+import { isGifWebSupported } from 'shared/meta/selectors'
 
 export function kernelConfigForRenderer(): KernelConfigForRenderer {
   const versions = injectVersions({})
@@ -27,7 +28,11 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
       nameValidRegex: nameValidRegex.toString().replace(/[/]/g, '')
     },
     debugConfig: undefined,
-    gifSupported: false,
+    gifSupported:
+      typeof (window as any).OffscreenCanvas !== 'undefined' &&
+      typeof (window as any).OffscreenCanvasRenderingContext2D === 'function' &&
+      !WSS_ENABLED &&
+      isGifWebSupported(globalState),
     network,
     validWorldRanges: getWorld().validWorldRanges,
     kernelVersion: versions['@dcl/kernel'] || 'unknown-kernel-version',


### PR DESCRIPTION
Fix https://github.com/decentraland/unity-renderer/issues/3880

# What?

Uses a feature flag to enable/disable the web gif processor. If it's disabled, it will use the unity gif processor.