### PR TITLE
feat: add FriendsKernelService

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@dcl/hashing": "^1.1.2",
         "@dcl/kernel-interface": "^2.0.0-20210922153939.commit-017905d",
         "@dcl/legacy-ecs": "^6.11.8",
-        "@dcl/protocol": "^1.0.0-3766287015.commit-7d88411",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3858115792.commit-2b92c76.tgz",
         "@dcl/rpc": "^1.1.1",
         "@dcl/scene-runtime": "^7.0.3-20221223152034.commit-23102ad",
         "@dcl/schemas": "^5.29.0",
@@ -278,9 +278,10 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-3766287015.commit-7d88411",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3766287015.commit-7d88411.tgz",
-      "integrity": "sha512-KY3AeHcqzPDoThYA6nggCyQLVSdGP/97yvtUi+dlg+bHVMrLbYPjFLpRQZ+1mAl446aE5jvq1HYpyAh8eckP1w==",
+      "version": "1.0.0-3858115792.commit-2b92c76",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3858115792.commit-2b92c76.tgz",
+      "integrity": "sha512-cO+4lF0vfG4xu/ZgkX5xrlLIA0eAFAr9b8ocHBhz037Hrl1a6vb64+Si4mhetotpgK/NZtZJAO9knUzAx0BSlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ts-proto": "^1.126.1"
       }
@@ -8311,9 +8312,8 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "@dcl/protocol": {
-      "version": "1.0.0-3766287015.commit-7d88411",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3766287015.commit-7d88411.tgz",
-      "integrity": "sha512-KY3AeHcqzPDoThYA6nggCyQLVSdGP/97yvtUi+dlg+bHVMrLbYPjFLpRQZ+1mAl446aE5jvq1HYpyAh8eckP1w==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3858115792.commit-2b92c76.tgz",
+      "integrity": "sha512-cO+4lF0vfG4xu/ZgkX5xrlLIA0eAFAr9b8ocHBhz037Hrl1a6vb64+Si4mhetotpgK/NZtZJAO9knUzAx0BSlw==",
       "requires": {
         "ts-proto": "^1.126.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@dcl/hashing": "^1.1.2",
         "@dcl/kernel-interface": "^2.0.0-20210922153939.commit-017905d",
         "@dcl/legacy-ecs": "^6.11.8",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3858115792.commit-2b92c76.tgz",
+        "@dcl/protocol": "^1.0.0-3874844989.commit-d6daab3",
         "@dcl/rpc": "^1.1.1",
         "@dcl/scene-runtime": "^7.0.3-20221223152034.commit-23102ad",
         "@dcl/schemas": "^5.29.0",
@@ -278,10 +278,9 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-3858115792.commit-2b92c76",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3858115792.commit-2b92c76.tgz",
-      "integrity": "sha512-cO+4lF0vfG4xu/ZgkX5xrlLIA0eAFAr9b8ocHBhz037Hrl1a6vb64+Si4mhetotpgK/NZtZJAO9knUzAx0BSlw==",
-      "license": "Apache-2.0",
+      "version": "1.0.0-3874844989.commit-d6daab3",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3874844989.commit-d6daab3.tgz",
+      "integrity": "sha512-yS11FNRKfaMzypE8jeFY/6kkuP7Q2NaJ9bvQg4sm5lELiykU2/NvVTOdlBLCr3eiLusI1ik6cv1JPdd1XRG07g==",
       "dependencies": {
         "ts-proto": "^1.126.1"
       }
@@ -8312,8 +8311,9 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "@dcl/protocol": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3858115792.commit-2b92c76.tgz",
-      "integrity": "sha512-cO+4lF0vfG4xu/ZgkX5xrlLIA0eAFAr9b8ocHBhz037Hrl1a6vb64+Si4mhetotpgK/NZtZJAO9knUzAx0BSlw==",
+      "version": "1.0.0-3874844989.commit-d6daab3",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3874844989.commit-d6daab3.tgz",
+      "integrity": "sha512-yS11FNRKfaMzypE8jeFY/6kkuP7Q2NaJ9bvQg4sm5lELiykU2/NvVTOdlBLCr3eiLusI1ik6cv1JPdd1XRG07g==",
       "requires": {
         "ts-proto": "^1.126.1"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@dcl/hashing": "^1.1.2",
     "@dcl/kernel-interface": "^2.0.0-20210922153939.commit-017905d",
     "@dcl/legacy-ecs": "^6.11.8",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3858115792.commit-2b92c76.tgz",
+    "@dcl/protocol": "^1.0.0-3874844989.commit-d6daab3",
     "@dcl/rpc": "^1.1.1",
     "@dcl/scene-runtime": "^7.0.3-20221223152034.commit-23102ad",
     "@dcl/schemas": "^5.29.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@dcl/hashing": "^1.1.2",
     "@dcl/kernel-interface": "^2.0.0-20210922153939.commit-017905d",
     "@dcl/legacy-ecs": "^6.11.8",
-    "@dcl/protocol": "^1.0.0-3766287015.commit-7d88411",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3858115792.commit-2b92c76.tgz",
     "@dcl/rpc": "^1.1.1",
     "@dcl/scene-runtime": "^7.0.3-20221223152034.commit-23102ad",
     "@dcl/schemas": "^5.29.0",

--- a/packages/renderer-protocol/inverseRpc/rpcServer.ts
+++ b/packages/renderer-protocol/inverseRpc/rpcServer.ts
@@ -3,6 +3,7 @@ import { RendererProtocolContext } from './context'
 import { registerEmotesKernelService } from './services/emotesService'
 import { registerAnalyticsKernelService } from './services/analyticsService'
 import { registerFriendRequestKernelService } from './services/friendRequestService'
+import { registerFriendsKernelService } from './services/friendsService'
 
 export function createRendererProtocolInverseRpcServer(transport: Transport) {
   const server = createRpcServer<RendererProtocolContext>({})
@@ -23,4 +24,5 @@ async function registerKernelServices(serverPort: RpcServerPort<RendererProtocol
   registerEmotesKernelService(serverPort)
   registerAnalyticsKernelService(serverPort)
   registerFriendRequestKernelService(serverPort)
+  registerFriendsKernelService(serverPort)
 }

--- a/packages/renderer-protocol/inverseRpc/services/friendsService.ts
+++ b/packages/renderer-protocol/inverseRpc/services/friendsService.ts
@@ -1,0 +1,35 @@
+import { RpcServerPort } from '@dcl/rpc'
+import { RendererProtocolContext } from '../context'
+import * as codegen from '@dcl/rpc/dist/codegen'
+import {
+  FriendsKernelServiceDefinition,
+  GetFriendshipStatusResponse
+} from '@dcl/protocol/out-ts/decentraland/renderer/kernel_services/friends_kernel.gen'
+import { getFriendshipStatus } from 'shared/friends/sagas'
+
+export function registerFriendsKernelService(port: RpcServerPort<RendererProtocolContext>) {
+  codegen.registerService(port, FriendsKernelServiceDefinition, async () => ({
+    async getFriendshipStatus(req, _) {
+      const handleGetFriendship = await handleRequest(getFriendshipStatus, req)
+
+      const response: GetFriendshipStatusResponse = {
+        status: handleGetFriendship
+      }
+
+      return response
+    }
+  }))
+}
+
+/**
+ * Abstract the flow of request handling of friend requests.
+ * @param handler - a function that takes in a request object and returns a Promise of a ResponseType object.
+ * @param req - a request object.
+ */
+async function handleRequest<T, U>(handler: (r: T) => U, req: T) {
+  // Handle request
+  const internalResponse = await handler(req)
+
+  // Send response back to renderer
+  return internalResponse
+}

--- a/packages/renderer-protocol/inverseRpc/services/friendsService.ts
+++ b/packages/renderer-protocol/inverseRpc/services/friendsService.ts
@@ -10,26 +10,13 @@ import { getFriendshipStatus } from 'shared/friends/sagas'
 export function registerFriendsKernelService(port: RpcServerPort<RendererProtocolContext>) {
   codegen.registerService(port, FriendsKernelServiceDefinition, async () => ({
     async getFriendshipStatus(req, _) {
-      const handleGetFriendship = await handleRequest(getFriendshipStatus, req)
+      const status = getFriendshipStatus(req)
 
       const response: GetFriendshipStatusResponse = {
-        status: handleGetFriendship
+        status
       }
 
       return response
     }
   }))
-}
-
-/**
- * Abstract the flow of request handling of friends kernel service.
- * @param handler - a function that takes in a request object and returns a Promise of a ResponseType object.
- * @param req - a request object.
- */
-async function handleRequest<T, U>(handler: (r: T) => U, req: T) {
-  // Handle request
-  const internalResponse = await handler(req)
-
-  // Send response back to renderer
-  return internalResponse
 }

--- a/packages/renderer-protocol/inverseRpc/services/friendsService.ts
+++ b/packages/renderer-protocol/inverseRpc/services/friendsService.ts
@@ -22,7 +22,7 @@ export function registerFriendsKernelService(port: RpcServerPort<RendererProtoco
 }
 
 /**
- * Abstract the flow of request handling of friend requests.
+ * Abstract the flow of request handling of friends kernel service.
  * @param handler - a function that takes in a request object and returns a Promise of a ResponseType object.
  * @param req - a request object.
  */

--- a/packages/shared/friends/sagas.ts
+++ b/packages/shared/friends/sagas.ts
@@ -735,7 +735,8 @@ export async function getFriends(request: GetFriendsPayload) {
 }
 
 export function getFriendshipStatus(request: GetFriendshipStatusRequest) {
-  const userId = getUserIdFromMatrix(request.userId)
+  // The userId is expected to always come from Renderer and follow the pattern `0x1111ada11111`
+  const userId = request.userId
   const state = store.getState()
 
   // Check user status

--- a/packages/shared/friends/selectors.ts
+++ b/packages/shared/friends/selectors.ts
@@ -79,8 +79,15 @@ export const isFriend = (store: RootFriendsState, userId: string) => store.frien
 /**
  * Return true if the friend request has already been sent (toFriendRequests). Otherwise, false.
  */
-export const isPendingRequest = (store: RootFriendsState, userId: string) => {
+export const isToPendingRequest = (store: RootFriendsState, userId: string) => {
   return store.friends.toFriendRequests.filter((request) => request.userId === userId).length > 0
+}
+
+/**
+ * Return true if the friend request has already been received (fromFriendRequests). Otherwise, false.
+ */
+export const isFromPendingRequest = (store: RootFriendsState, userId: string) => {
+  return store.friends.fromFriendRequests.filter((request) => request.userId === userId).length > 0
 }
 
 export const getLastStatusOfFriends = (store: RootFriendsState) => store.friends.lastStatusOfFriends

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -578,7 +578,7 @@ describe('Friends sagas', () => {
     describe('When the given user id is not a friend and it is not a pending request', () => {
       it('Should return FriendshipStatus.NONE', () => {
         const request: GetFriendshipStatusRequest = {
-          userId: 'some_user_id' // 0xa1
+          userId: 'some_user_id'
         }
 
         const expectedResponse = FriendshipStatus.NONE

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -575,37 +575,43 @@ describe('Friends sagas', () => {
       sinon.reset()
     })
 
-    it('Should return FriendshipStatus.NONE, when the given user id is not a friend and it is not a pending request', () => {
-      const request: GetFriendshipStatusRequest = {
-        userId: 'some_user_id'
-      }
+    context('When the given user id is not a friend and it is not a pending request', () => {
+      it('Should return FriendshipStatus.NONE', () => {
+        const request: GetFriendshipStatusRequest = {
+          userId: 'some_user_id'
+        }
 
-      const expectedResponse = FriendshipStatus.NONE
+        const expectedResponse = FriendshipStatus.NONE
 
-      const response = friendsSagas.getFriendshipStatus(request)
-      assert.match(response, expectedResponse)
+        const response = friendsSagas.getFriendshipStatus(request)
+        assert.match(response, expectedResponse)
+      })
     })
 
-    it('Should return FriendshipStatus.APPROVED, when the given user id is a friend', () => {
-      const request: GetFriendshipStatusRequest = {
-        userId: '0xa1'
-      }
+    context('When the given user id is a friend', () => {
+      it('Should return FriendshipStatus.APPROVED', () => {
+        const request: GetFriendshipStatusRequest = {
+          userId: '0xa1'
+        }
 
-      const expectedResponse = FriendshipStatus.APPROVED
+        const expectedResponse = FriendshipStatus.APPROVED
 
-      const response = friendsSagas.getFriendshipStatus(request)
-      assert.match(response, expectedResponse)
+        const response = friendsSagas.getFriendshipStatus(request)
+        assert.match(response, expectedResponse)
+      })
     })
 
-    it('Should return FriendshipStatus.REQUESTED_TO, when the given user id is a to pending request', () => {
-      const request: GetFriendshipStatusRequest = {
-        userId: '0xa2'
-      }
+    context('When the given user id is a to pending request', () => {
+      it('Should return FriendshipStatus.REQUESTED_TO', () => {
+        const request: GetFriendshipStatusRequest = {
+          userId: '0xa2'
+        }
 
-      const expectedResponse = FriendshipStatus.REQUESTED_TO
+        const expectedResponse = FriendshipStatus.REQUESTED_TO
 
-      const response = friendsSagas.getFriendshipStatus(request)
-      assert.match(response, expectedResponse)
+        const response = friendsSagas.getFriendshipStatus(request)
+        assert.match(response, expectedResponse)
+      })
     })
   })
 })

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -564,7 +564,7 @@ describe('Friends sagas', () => {
     })
   })
 
-  describe.only('Get Friendship Status', () => {
+  describe('Get Friendship Status', () => {
     beforeEach(() => {
       const { store } = buildStore(mockStoreCalls())
       globalThis.globalStore = store
@@ -575,43 +575,37 @@ describe('Friends sagas', () => {
       sinon.reset()
     })
 
-    describe('When the given user id is not a friend and it is not a pending request', () => {
-      it('Should return FriendshipStatus.NONE', () => {
-        const request: GetFriendshipStatusRequest = {
-          userId: 'some_user_id'
-        }
+    it('Should return FriendshipStatus.NONE, when the given user id is not a friend and it is not a pending request', () => {
+      const request: GetFriendshipStatusRequest = {
+        userId: 'some_user_id'
+      }
 
-        const expectedResponse = FriendshipStatus.NONE
+      const expectedResponse = FriendshipStatus.NONE
 
-        const response = friendsSagas.getFriendshipStatus(request)
-        assert.match(response, expectedResponse)
-      })
+      const response = friendsSagas.getFriendshipStatus(request)
+      assert.match(response, expectedResponse)
     })
 
-    describe('When the given user id is a friend', () => {
-      it('Should return FriendshipStatus.APPROVED', () => {
-        const request: GetFriendshipStatusRequest = {
-          userId: '0xa1'
-        }
+    it('Should return FriendshipStatus.APPROVED, when the given user id is a friend', () => {
+      const request: GetFriendshipStatusRequest = {
+        userId: '0xa1'
+      }
 
-        const expectedResponse = FriendshipStatus.APPROVED
+      const expectedResponse = FriendshipStatus.APPROVED
 
-        const response = friendsSagas.getFriendshipStatus(request)
-        assert.match(response, expectedResponse)
-      })
+      const response = friendsSagas.getFriendshipStatus(request)
+      assert.match(response, expectedResponse)
     })
 
-    describe('When the given user id is a to pending request', () => {
-      it('Should return FriendshipStatus.REQUESTED_TO', () => {
-        const request: GetFriendshipStatusRequest = {
-          userId: '0xa2'
-        }
+    it('Should return FriendshipStatus.REQUESTED_TO, when the given user id is a to pending request', () => {
+      const request: GetFriendshipStatusRequest = {
+        userId: '0xa2'
+      }
 
-        const expectedResponse = FriendshipStatus.REQUESTED_TO
+      const expectedResponse = FriendshipStatus.REQUESTED_TO
 
-        const response = friendsSagas.getFriendshipStatus(request)
-        assert.match(response, expectedResponse)
-      })
+      const response = friendsSagas.getFriendshipStatus(request)
+      assert.match(response, expectedResponse)
     })
   })
 })

--- a/test/unit/friends.saga.test.ts
+++ b/test/unit/friends.saga.test.ts
@@ -10,7 +10,7 @@ import {
   PresenceStatus,
   FriendshipAction
 } from 'shared/types'
-import sinon from 'sinon'
+import sinon, { assert } from 'sinon'
 import * as friendsSagas from '../../packages/shared/friends/sagas'
 import { setMatrixClient } from 'shared/friends/actions'
 import * as friendsSelectors from 'shared/friends/selectors'
@@ -36,6 +36,10 @@ import { StoreEnhancer } from 'redux'
 import { reducers } from 'shared/store/rootReducer'
 import { getParcelPosition } from 'shared/scene-loader/selectors'
 import { encodeFriendRequestId } from 'shared/friends/utils'
+import {
+  FriendshipStatus,
+  GetFriendshipStatusRequest
+} from '@dcl/protocol/out-ts/decentraland/renderer/kernel_services/friends_kernel.gen'
 
 function getMockedAvatar(userId: string, name: string): ProfileUserInfo {
   return {
@@ -557,6 +561,57 @@ describe('Friends sagas', () => {
         .dispatch(setMatrixClient(stubClient))
         .silentRun()
       unityMock.verify()
+    })
+  })
+
+  describe.only('Get Friendship Status', () => {
+    beforeEach(() => {
+      const { store } = buildStore(mockStoreCalls())
+      globalThis.globalStore = store
+    })
+
+    afterEach(() => {
+      sinon.restore()
+      sinon.reset()
+    })
+
+    describe('When the given user id is not a friend and it is not a pending request', () => {
+      it('Should return FriendshipStatus.NONE', () => {
+        const request: GetFriendshipStatusRequest = {
+          userId: 'some_user_id' // 0xa1
+        }
+
+        const expectedResponse = FriendshipStatus.NONE
+
+        const response = friendsSagas.getFriendshipStatus(request)
+        assert.match(response, expectedResponse)
+      })
+    })
+
+    describe('When the given user id is a friend', () => {
+      it('Should return FriendshipStatus.APPROVED', () => {
+        const request: GetFriendshipStatusRequest = {
+          userId: '0xa1'
+        }
+
+        const expectedResponse = FriendshipStatus.APPROVED
+
+        const response = friendsSagas.getFriendshipStatus(request)
+        assert.match(response, expectedResponse)
+      })
+    })
+
+    describe('When the given user id is a to pending request', () => {
+      it('Should return FriendshipStatus.REQUESTED_TO', () => {
+        const request: GetFriendshipStatusRequest = {
+          userId: '0xa2'
+        }
+
+        const expectedResponse = FriendshipStatus.REQUESTED_TO
+
+        const response = friendsSagas.getFriendshipStatus(request)
+        assert.match(response, expectedResponse)
+      })
     })
   })
 })


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Following the definition outcome of this issue [decentraland/protocol#102](https://github.com/decentraland/protocol/issues/102), implement the service in kernel to retrieve the current friendship status of the current player for a given user id.

- Closes #825 
