### PR TITLE
fix: send friendshipStatus when updateUserPresence

### DIFF
--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -529,11 +529,19 @@ type Realm = {
   serverName: string
 }
 
+export enum FriendshipStatusOld {
+  NOT_FRIEND,
+  FRIEND,
+  REQUESTED_FROM,
+  REQUESTED_TO
+}
+
 export type UpdateUserStatusMessage = {
   userId: string
   realm: Realm | undefined
   position: Vector2Component | undefined
   presence: PresenceStatus
+  friendshipStatus: FriendshipStatusOld
 }
 
 export interface AddFriendsPayload {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Explorer expects the friendshipStatus attribute to be included when calling the UpdateUserPresence message, as it prevents inconsistencies when updating user presence.