### PR TITLE
feat: A/B test support for new tutorial

### DIFF
--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -26,6 +26,7 @@ import { WorldConfig } from 'shared/meta/types'
 import {
   getFeatureFlagEnabled,
   getFeatureFlags,
+  getFeatureFlagVariantName,
   getFeatureFlagVariantValue,
   getWorldConfig
 } from 'shared/meta/selectors'
@@ -255,7 +256,7 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
   // this code should be removed once the "hardcoded" tutorial is removed
   // from the renderer
   if (NEEDS_TUTORIAL) {
-    if (!getFeatureFlagEnabled(store.getState(), 'new_tutorial')) {
+    if (getFeatureFlagVariantName(store.getState(), 'new_tutorial_variant') === 'disabled') {
       const enableNewTutorialCamera = worldConfig ? worldConfig.enableNewTutorialCamera ?? false : false
       const tutorialConfig = {
         //TODO: hardcoding this value to true since currently default scene is the xmas scnee.
@@ -268,7 +269,7 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
       i.ConfigureTutorial(profile.tutorialStep, tutorialConfig)
     } else {
       try {
-        const realm: string | undefined = getFeatureFlagVariantValue(store.getState(), 'new_tutorial')
+        const realm: string | undefined = getFeatureFlagVariantValue(store.getState(), 'new_tutorial_variant')
         if (realm) {
           await changeRealm(realm)
           trackEvent('onboarding_started', { onboardingRealm: realm })

--- a/packages/shared/meta/selectors.ts
+++ b/packages/shared/meta/selectors.ts
@@ -103,6 +103,21 @@ export function getFeatureFlagEnabled(store: RootMetaState, featureName: Feature
   return false
 }
 
+/**
+ * Returns the feature flag variant name
+ */
+export function getFeatureFlagVariantName(store: RootMetaState, featureName: FeatureFlagsName): string {
+  const ff = getFeatureFlags(store)
+  if(getFeatureFlagEnabled(store, featureName)) {
+    const variant = ff.variants[featureName]
+    if (variant && variant.enabled) {
+      return variant.name
+    }
+    return 'undefined';
+  }
+  return 'undefined';
+}
+
 export function getFeatureFlags(store: RootMetaState): FeatureFlag {
   return store.meta.config.featureFlagsV2 || { flags: {}, variants: {} }
 }

--- a/packages/shared/meta/selectors.ts
+++ b/packages/shared/meta/selectors.ts
@@ -108,14 +108,14 @@ export function getFeatureFlagEnabled(store: RootMetaState, featureName: Feature
  */
 export function getFeatureFlagVariantName(store: RootMetaState, featureName: FeatureFlagsName): string {
   const ff = getFeatureFlags(store)
-  if(getFeatureFlagEnabled(store, featureName)) {
+  if (getFeatureFlagEnabled(store, featureName)) {
     const variant = ff.variants[featureName]
     if (variant && variant.enabled) {
       return variant.name
     }
-    return 'undefined';
+    return 'undefined'
   }
-  return 'undefined';
+  return 'undefined'
 }
 
 export function getFeatureFlags(store: RootMetaState): FeatureFlag {

--- a/packages/shared/meta/types.ts
+++ b/packages/shared/meta/types.ts
@@ -46,7 +46,7 @@ export type FeatureFlagsName =
   | 'gif-web'
   | 'ping_enabled'
   | 'use-synapse-server'
-  | 'new_tutorial'
+  | 'new_tutorial_variant'
 
 export type BannedUsers = Record<string, Ban[]>
 


### PR DESCRIPTION
# What? <!-- what is this PR? -->

Adding support for `new tutorial_variant` feature flag to A/B test the new flow

# Why? <!-- Explain the reason -->
To support A/B test we need to be compatible with https://adr.decentraland.org/adr/ADR-73 and use variant to distinguish the cohort we are targeting.
