### PR TITLE
fix: don't trigger new onboarding for users entering via deeplink

### DIFF
--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -268,7 +268,6 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
 
       i.ConfigureTutorial(profile.tutorialStep, tutorialConfig)
     } else {
-      console.log("GOING TO CHANGE REALM " + IS_NEW_TUTORIAL_DISABLED)
       try {
         const realm: string | undefined = getFeatureFlagVariantValue(store.getState(), 'new_tutorial_variant')
         if (realm) {

--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -252,25 +252,17 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
 
   const NEEDS_TUTORIAL = RESET_TUTORIAL || !profile.tutorialStep
 
-  console.log("PROFILE TUTORIAL STEP " + HAS_INITIAL_POSITION_MARK)
-  console.log("PROFILE TUTORIAL STEP " + profile.tutorialStep)
-  console.log("PROFILE TUTORIAL STEP BOOL " + !profile.tutorialStep)
-
   // only enable the old tutorial if the feature flag new_tutorial is off
   // this code should be removed once the "hardcoded" tutorial is removed
   // from the renderer
   if (NEEDS_TUTORIAL) {
     const NEW_TUTORIAL_FEATURE_FLAG = getFeatureFlagVariantName(store.getState(), 'new_tutorial_variant')
     const IS_NEW_TUTORIAL_DISABLED =
-      NEW_TUTORIAL_FEATURE_FLAG === 'disabled' || NEW_TUTORIAL_FEATURE_FLAG === 'undefined'
-      console.log("IS_NEW_TUTORIAL_DISABLED " + IS_NEW_TUTORIAL_DISABLED)
+      NEW_TUTORIAL_FEATURE_FLAG === 'disabled' || NEW_TUTORIAL_FEATURE_FLAG === 'undefined' || HAS_INITIAL_POSITION_MARK
     if (IS_NEW_TUTORIAL_DISABLED) {
       const enableNewTutorialCamera = worldConfig ? worldConfig.enableNewTutorialCamera ?? false : false
       const tutorialConfig = {
-        //TODO: hardcoding this value to true since currently default scene is the xmas scnee.
-        // If this is no hardcoded, the tutorial will never start on a default scene that is not genesis plaza
-        // We should plan a way which allows different default scenes
-        fromDeepLink: true,
+        fromDeepLink: HAS_INITIAL_POSITION_MARK,
         enableNewTutorialCamera: enableNewTutorialCamera
       }
 

--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -262,6 +262,7 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
     const NEW_TUTORIAL_FEATURE_FLAG = getFeatureFlagVariantName(store.getState(), 'new_tutorial_variant')
     const IS_NEW_TUTORIAL_DISABLED =
       NEW_TUTORIAL_FEATURE_FLAG === 'disabled' || NEW_TUTORIAL_FEATURE_FLAG === 'undefined'
+      console.log("IS_NEW_TUTORIAL_DISABLED " + IS_NEW_TUTORIAL_DISABLED)
     if (IS_NEW_TUTORIAL_DISABLED) {
       const enableNewTutorialCamera = worldConfig ? worldConfig.enableNewTutorialCamera ?? false : false
       const tutorialConfig = {
@@ -274,6 +275,7 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
 
       i.ConfigureTutorial(profile.tutorialStep, tutorialConfig)
     } else {
+      console.log("GOING TO CHANGE REALM " + IS_NEW_TUTORIAL_DISABLED)
       try {
         const realm: string | undefined = getFeatureFlagVariantValue(store.getState(), 'new_tutorial_variant')
         if (realm) {

--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -252,6 +252,7 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
 
   const NEEDS_TUTORIAL = RESET_TUTORIAL || !profile.tutorialStep
 
+  console.log("PROFILE TUTORIAL STEP " + HAS_INITIAL_POSITION_MARK)
   console.log("PROFILE TUTORIAL STEP " + profile.tutorialStep)
   console.log("PROFILE TUTORIAL STEP BOOL " + !profile.tutorialStep)
 

--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -252,6 +252,9 @@ async function loadWebsiteSystems(options: KernelOptions['kernelOptions']) {
 
   const NEEDS_TUTORIAL = RESET_TUTORIAL || !profile.tutorialStep
 
+  console.log("PROFILE TUTORIAL STEP " + profile.tutorialStep)
+  console.log("PROFILE TUTORIAL STEP BOOL " + !profile.tutorialStep)
+
   // only enable the old tutorial if the feature flag new_tutorial is off
   // this code should be removed once the "hardcoded" tutorial is removed
   // from the renderer

--- a/packages/shared/profiles/selectors.ts
+++ b/packages/shared/profiles/selectors.ts
@@ -39,6 +39,7 @@ export const getProfile = (store: RootProfileState, userId: string): Avatar | nu
 
 export const getCurrentUserProfile = (store: RootProfileState & RootSessionState): Avatar | null => {
   const currentUserId = getCurrentUserId(store)
+  console.log("CURRENT USER PORFILE " + currentUserId)
   return currentUserId ? getProfile(store, currentUserId) : null
 }
 

--- a/packages/shared/profiles/selectors.ts
+++ b/packages/shared/profiles/selectors.ts
@@ -39,7 +39,6 @@ export const getProfile = (store: RootProfileState, userId: string): Avatar | nu
 
 export const getCurrentUserProfile = (store: RootProfileState & RootSessionState): Avatar | null => {
   const currentUserId = getCurrentUserId(store)
-  console.log("CURRENT USER PORFILE " + currentUserId)
   return currentUserId ? getProfile(store, currentUserId) : null
 }
 


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Added extra check for triggering new onboarding only for users not entering the platform via deeplink.
